### PR TITLE
feat(webapi): add staging environment for WebAPI

### DIFF
--- a/.env.webapi-sta.example
+++ b/.env.webapi-sta.example
@@ -1,0 +1,25 @@
+# dotBento WebApi Staging Environment Variables
+# Copy this file to .env-webapi-sta and fill in your values
+
+# ===========================================
+# REQUIRED - API will not start without these
+# ===========================================
+
+# PostgreSQL connection string (staging database)
+DatabaseConnectionString=Host=localhost;Port=5432;Username=postgres;Password=password;Database=bento;Command Timeout=60;Timeout=60;Persist Security Info=True
+
+# Redis/Valkey connection string (for distributed caching)
+Valkey__ConnectionString=valkey-prod:6379
+
+# API key for authentication (client must send this in X-Api-Key header)
+ApiKey=your_staging_api_key_here
+
+# ===========================================
+# OPTIONAL
+# ===========================================
+
+# Environment name
+Environment=staging
+
+# Grafana Loki logging
+LokiUrl=http://loki:3100

--- a/.github/workflows/docker-prerelease.yml
+++ b/.github/workflows/docker-prerelease.yml
@@ -104,13 +104,13 @@ jobs:
             # Only update the bot-sta service, NOT bot-prod
             sed -i '/bot-sta:/,/image:/s|ghcr.io/thebentobot/dotbento:[^ ]*|ghcr.io/thebentobot/dotbento:${{ env.NEW_TAG }}|' $USER_DIR/bento/docker-compose.yml
 
-            # Only update the WebAPI service
-            sed -i '/webapi:/,/image:/s|ghcr.io/thebentobot/dotbento-webapi:[^ ]*|ghcr.io/thebentobot/dotbento-webapi:${{ env.NEW_TAG }}|' $USER_DIR/bento/docker-compose.yml
-            
-            # Stop and remove any existing instance of bot-sta to prevent name conflicts
-            docker compose -f $USER_DIR/bento/docker-compose.yml down bot-sta webapi || true
-            docker compose -f $USER_DIR/bento/docker-compose.yml rm -f bot-sta webapi || true
+            # Only update the staging WebAPI service
+            sed -i '/webapi-sta:/,/image:/s|ghcr.io/thebentobot/dotbento-webapi:[^ ]*|ghcr.io/thebentobot/dotbento-webapi:${{ env.NEW_TAG }}|' $USER_DIR/bento/docker-compose.yml
+
+            # Stop and remove any existing instance of bot-sta and webapi-sta to prevent name conflicts
+            docker compose -f $USER_DIR/bento/docker-compose.yml down bot-sta webapi-sta || true
+            docker compose -f $USER_DIR/bento/docker-compose.yml rm -f bot-sta webapi-sta || true
 
             # Pull the new image and redeploy the service
-            docker compose -f $USER_DIR/bento/docker-compose.yml pull bot-sta webapi
-            docker compose -f $USER_DIR/bento/docker-compose.yml up -d bot-sta webapi
+            docker compose -f $USER_DIR/bento/docker-compose.yml pull bot-sta webapi-sta
+            docker compose -f $USER_DIR/bento/docker-compose.yml up -d bot-sta webapi-sta

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -136,7 +136,7 @@ services:
 #      - bento_net
 #      - web
 
-  # WebAPI
+  # WebAPI - Production
   webapi:
     image: ghcr.io/thebentobot/dotbento-webapi
     container_name: webapi
@@ -145,6 +145,19 @@ services:
       - .env-webapi
     ports:
       - "8080:8080"
+    networks:
+      - bento_net
+      - web
+
+  # WebAPI - Staging
+  webapi-sta:
+    image: ghcr.io/thebentobot/dotbento-webapi
+    container_name: webapi-sta
+    restart: unless-stopped
+    env_file:
+      - .env-webapi-sta
+    ports:
+      - "8081:8080"
     networks:
       - bento_net
       - web


### PR DESCRIPTION
## Summary
- Added a `webapi-sta` staging service to `docker-compose.prod.yml` on port 8081 with its own `.env-webapi-sta` env file
- Updated `docker-prerelease.yml` to deploy `webapi-sta` instead of `webapi`, so pre-release deploys no longer touch the production WebAPI
- Added `.env.webapi-sta.example` as a reference for the staging env config

## Server setup required
After merging, the following is needed on the VPS:
1. Create `.env-webapi-sta` in the bento directory with staging-specific values
2. Add a Cloudflare DNS A record: `api-staging` -> VPS IP
3. Add an nginx server block proxying `api-staging.bentobot.xyz` to `127.0.0.1:8081`

## Test plan
- [x] Verify `docker-prerelease.yml` targets `webapi-sta` and not `webapi`
- [x] Verify `docker-release.yml` still targets `webapi` (production) unchanged
- [ ] After deploy, confirm staging API responds on port 8081
- [ ] Confirm production API on port 8080 is unaffected by pre-release deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)