### PR TITLE
fix: make Docker health checks work for bot and webapi

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,6 +18,5 @@ RUN dotnet publish "dotBento.Bot.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=5 CMD find healthcheck -mmin -1
 ENTRYPOINT ["dotnet", "dotBento.Bot.dll"]
-
-HEALTHCHECK --interval=20s --timeout=20s --retries=90 CMD find healthcheck -mmin -1

--- a/src/dotBento.Bot/Startup.cs
+++ b/src/dotBento.Bot/Startup.cs
@@ -152,9 +152,20 @@ public sealed class Startup
         provider.GetRequiredService<ClientLeftGuildHandler>();
         
         await provider.GetRequiredService<BotService>().StartAsync();
-        
+
         using var server = new BackgroundJobServer();
-        
+
+        // Touch a file every 30s so the Docker HEALTHCHECK (find healthcheck -mmin -1) sees the process as alive
+        var healthCheckPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "healthcheck");
+        _ = Task.Run(async () =>
+        {
+            while (true)
+            {
+                await File.WriteAllTextAsync(healthCheckPath, DateTimeOffset.UtcNow.ToString("O"));
+                await Task.Delay(TimeSpan.FromSeconds(30));
+            }
+        });
+
         await Task.Delay(-1);
     }
 

--- a/src/dotBento.WebApi/Dockerfile
+++ b/src/dotBento.WebApi/Dockerfile
@@ -2,6 +2,7 @@
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
@@ -23,4 +24,5 @@ RUN dotnet publish "dotBento.WebApi.csproj" -c $BUILD_CONFIGURATION -o /app/publ
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 CMD curl -f http://localhost:8080/health || exit 1
 ENTRYPOINT ["dotnet", "dotBento.WebApi.dll"]

--- a/src/dotBento.WebApi/Program.cs
+++ b/src/dotBento.WebApi/Program.cs
@@ -61,6 +61,7 @@ else
     throw new InvalidOperationException("Valkey/Redis connection string is not configured. Set Valkey:ConnectionString (env: VALKEY__CONNECTIONSTRING) or Redis:ConnectionString (env: REDIS__CONNECTIONSTRING) or RedisConnectionString (env: REDISCONNECTIONSTRING) to enable the shared cache.");
 }
 
+builder.Services.AddHealthChecks();
 builder.Services.AddOpenApi();
 
 builder.Services.AddScoped<dotBento.Infrastructure.Services.ProfileService>();
@@ -101,6 +102,7 @@ if (app.Environment.IsDevelopment())
 {
     app.UseHttpsRedirection();
 }
+app.MapHealthChecks("/health");
 app.UseMiddleware<ApiKeyMiddleware>();
 app.UseAuthorization();
 app.UseMetricServer();


### PR DESCRIPTION
## Summary

- **Bot**: adds a background loop in `Startup.RunAsync` that writes the current timestamp to `/app/healthcheck` every 30 seconds, so the existing `find healthcheck -mmin -1` Docker `HEALTHCHECK` finally has a file to find. Also tightens the `HEALTHCHECK` parameters (`--start-period=120s`, `--retries=5`, `--interval=30s`) to be more sensible.
- **WebApi**: registers `AddHealthChecks()` and maps `GET /health` before `ApiKeyMiddleware` (so it's unauthenticated), installs `curl` in the base Docker image, and adds a `HEALTHCHECK` that curls `localhost:8080/health`.

Closes #454

## Test plan

- [ ] Build and run both Docker images locally; confirm `docker inspect --format='{{.State.Health.Status}}'` reports `healthy` within the configured start period
- [ ] Confirm `GET /health` on the WebApi returns `200 OK` without an API key
- [ ] Confirm containers no longer show `unhealthy` on the VPS after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)