### PR TITLE
docs: improve local dev setup with infrastructure-only docker compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Discord event handlers in `dotBento.Bot/Handlers/`:
 
 ### Configuration
 
-- Bot config: `src/dotBento.Bot/configs/config.json` or environment variables
+- Bot config: `.env` file at repo root (loaded automatically via DotNetEnv) or environment variables
 - Web API config: `src/dotBento.WebApi/appsettings.json` or environment variables
 - Required services: PostgreSQL, Valkey/Redis for distributed caching
 
@@ -78,10 +78,26 @@ Uses EF Core with PostgreSQL. The `BotDbContext` in `dotBento.EntityFramework/Co
 
 ### Docker Development
 
+The dev compose runs infrastructure only (Postgres, Valkey, Sushii image server). Run the bot and webapi locally with `dotnet run`.
+
 ```bash
-# Start local development environment (Postgres, Valkey, Sushii image server)
-docker compose -f src/docker-compose.dev.yml up
+# 1. Start infrastructure
+docker compose -f src/docker-compose.dev.yml up -d
+
+# 2. Copy env file and fill in your Discord token (first time only)
+cp .env.example .env
+
+# 3. Run the bot (in one terminal)
+dotnet run --project src/dotBento.Bot
+
+# 4. Run the web API (in another terminal, optional)
+dotnet run --project src/dotBento.WebApi
+
+# Stop infrastructure
+docker compose -f src/docker-compose.dev.yml down
 ```
+
+Postgres data is persisted in a Docker named volume (`postgres_data`) so your data survives restarts.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,41 @@ A Discord bot written in .NET. This repository is the improved .NET rewrite of [
 
 ## Getting started
 
-TBD soon™️
+### Prerequisites
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- [Docker](https://docs.docker.com/get-docker/) (for local infrastructure)
+- A Discord bot token from the [Discord Developer Portal](https://discord.com/developers/applications)
+
+### Local development
+
+1. **Start infrastructure** (Postgres, Valkey, Sushii image server):
+   ```bash
+   docker compose -f src/docker-compose.dev.yml up -d
+   ```
+
+2. **Configure environment** (first time only):
+   ```bash
+   cp .env.example .env
+   # Edit .env and set Discord__Token to your bot token
+   ```
+
+3. **Run the bot:**
+   ```bash
+   dotnet run --project src/dotBento.Bot
+   ```
+
+4. **Optionally run the web API** (in a separate terminal):
+   ```bash
+   cp .env.webapi.example .env.webapi  # fill in ApiKey
+   dotnet run --project src/dotBento.WebApi
+   ```
+
+5. **Stop infrastructure** when done:
+   ```bash
+   docker compose -f src/docker-compose.dev.yml down
+   ```
+
+Postgres data is persisted in a named Docker volume, so your database survives restarts.
 
 ## Relevant links
 - The commit linting rules follows Conventional Commits. You can read about the linting rules specifically [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)

--- a/src/docker-compose.dev.yml
+++ b/src/docker-compose.dev.yml
@@ -1,42 +1,42 @@
-# This is an example of a docker-compose file that can be used to run the bot locally. 
 services:
-  bot-local:
+  postgres:
+    image: postgres:17-alpine
+    container_name: bento-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: bento
     ports:
-      - "5000:80"
-    build: 
-      context: .
-      dockerfile: Dockerfile
-    develop:
-      watch:
-        - action: rebuild
-          path: .
-          target: /app
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U username -d bento"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
-      - web
       - bento_net
-    env_file:
-      - .env
 
-  webapi:
-    build:
-      context: ./src/dotBento.WebApi
-      dockerfile: Dockerfile
-    develop:
-      watch:
-        - action: rebuild
-          path: .
-          target: /app
+  valkey:
+    image: valkey/valkey:9-alpine
+    container_name: bento-valkey
+    restart: unless-stopped
+    command: ["valkey-server", "--save", "", "--appendonly", "no"]
     ports:
-      - "5027:5027"
-    env_file:
-      - .env
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
-      - web
       - bento_net
 
   sushii-image-server:
     image: ghcr.io/sushiibot/sushii-image-server:latest
-    container_name: sushii-image-server
+    container_name: bento-sushii
     restart: unless-stopped
     init: true
     cap_add:
@@ -46,31 +46,8 @@ services:
     networks:
       - bento_net
 
-  postgres:
-    image: postgres
-    container_name: postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: username
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: bento
-    ports:
-      - "5432:5432"
-    networks:
-      - bento_net
-
-  valkey-sta:
-    image: valkey/valkey:9-alpine
-    container_name: valkey-sta
-    restart: unless-stopped
-    command: [ "valkey-server", "--save", "", "--appendonly", "no" ]
-    ports:
-      - "6379:6379"
-    networks:
-      - bento_net
+volumes:
+  postgres_data:
 
 networks:
-  web:
-    internal: false
   bento_net:
-    external: false

--- a/src/docker-compose.dev.yml
+++ b/src/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:16-alpine
     container_name: bento-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

- Reworks `docker-compose.dev.yml` to infrastructure-only (Postgres, Valkey, Sushii image server) — removes the slow app container builds so devs run `dotnet run` locally
- Adds `AGENTS.md` symlink to `CLAUDE.md` for AI agent tooling compatibility
- Fills in the "Getting started" section in the README with a proper step-by-step local dev workflow
- Cleans up the dev compose: pinned Postgres to `17-alpine`, added health checks, named volume for data persistence, renamed containers to `bento-*` prefix

Closes #363

## Test plan

- [ ] `docker compose -f src/docker-compose.dev.yml up -d` starts all three infra services
- [ ] Postgres health check passes (`docker ps` shows healthy)
- [ ] `dotnet run --project src/dotBento.Bot` connects successfully
- [ ] `docker compose -f src/docker-compose.dev.yml down && up -d` preserves DB data via named volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)