### PR TITLE
refactor(bot): standardise ErrorEmbed

### DIFF
--- a/src/dotBento.Bot/Commands/SharedCommands/BannerCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/BannerCommand.cs
@@ -3,6 +3,7 @@ using Discord;
 using Discord.Rest;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Bot.Utilities;
 using dotBento.Infrastructure.Utilities;
 
@@ -15,13 +16,11 @@ public sealed class BannerCommand(StylingUtilities stylingUtilities)
         var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
         if (user.HasNoValue)
         {
-            embed.Embed.WithTitle("Error").WithDescription("That user does not exist.").WithColor(Color.Red);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "That user does not exist.");
         }
         if (user.Value.GetBannerUrl(ImageFormat.Auto, 2048) == null)
         {
-            embed.Embed.WithTitle("Error").WithDescription("That user does not have a banner.").WithColor(Color.Red);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "That user does not have a banner.");
         }
         var bannerColour = await stylingUtilities.GetDominantColorAsync(user.Value.GetBannerUrl(ImageFormat.WebP, 128));
         embed.Embed.WithTitle($"{StringUtilities.AddPossessiveS(user.Value.GlobalName)} User Profile Banner")

--- a/src/dotBento.Bot/Commands/SharedCommands/ChooseCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/ChooseCommand.cs
@@ -1,7 +1,7 @@
-using Discord;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 
 namespace dotBento.Bot.Commands.SharedCommands;
 
@@ -9,39 +9,26 @@ public static class ChooseCommand
 {
     public static Task<ResponseModel> Command(string options)
     {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-
         if (!options.Contains(','))
         {
-            embed.Embed.WithTitle("You need to separate options with commas")
-                .WithColor(Color.Red);
-            return Task.FromResult(embed);
+            return Task.FromResult(GenericEmbedService.ErrorEmbed("You need to separate options with commas"));
         }
         var listOfOptions = options.Trim().Split(",").ToList();
-        
+
+        var embed = new ResponseModel { ResponseType = ResponseType.Embed };
         switch (listOfOptions.Count)
         {
             case < 2:
-            {
-                embed.Embed.WithTitle("You need to provide at least 2 options")
-                    .WithDescription($"Well obviously the choice is **{listOfOptions[0]}**, but perhaps you wanted me to choose between a few more options other than one? 🙄")
-                    .WithColor(Color.Red);
-                break;
-            }
+                return Task.FromResult(GenericEmbedService.ErrorEmbed("You need to provide at least 2 options",
+                    $"Well obviously the choice is **{listOfOptions[0]}**, but perhaps you wanted me to choose between a few more options other than one? 🙄"));
             case > 20:
-            {
-                embed.Embed.WithTitle("You need to provide less than 20 options")
-                    .WithDescription($"I can't choose between {listOfOptions.Count} options, that's too many! 😱")
-                    .WithColor(Color.Red);
-                break;
-            }
+                return Task.FromResult(GenericEmbedService.ErrorEmbed("You need to provide less than 20 options",
+                    $"I can't choose between {listOfOptions.Count} options, that's too many! 😱"));
             default:
-            {
                 embed.Embed.WithTitle("I choose...")
                     .WithDescription($"**{ChooseOption(listOfOptions)}**")
                     .WithColor(DiscordConstants.BentoYellow);
                 break;
-            }
         }
         return Task.FromResult(embed);
     }

--- a/src/dotBento.Bot/Commands/SharedCommands/GameCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/GameCommand.cs
@@ -2,6 +2,7 @@ using Discord;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 using dotBento.Domain.Enums.Games;
 using dotBento.Domain.Extensions.Games;
 using dotBento.Infrastructure.Commands;
@@ -58,29 +59,20 @@ public sealed class GameCommand(GameCommands gameCommands)
     
     private static Task<(int min, int max, bool failedValidation, ResponseModel error)> ValidateUserInput(int? userMin, int? userMax)
     {
-        var errorEmbed = new ResponseModel { ResponseType = ResponseType.Embed };
         if (int.TryParse(userMin.ToString(), out var min).Equals(false))
         {
-            errorEmbed.Embed.WithTitle("The minimum number is not a valid number\nThe highest number I can roll is 1000 and the lowest is 1")
-                .WithColor(Color.Red);
-            return Task.FromResult((0, 0, true, errorEmbed));
+            return Task.FromResult((0, 0, true, GenericEmbedService.ErrorEmbed("The minimum number is not a valid number\nThe highest number I can roll is 1000 and the lowest is 1")));
         }
         if (int.TryParse(userMax.ToString(), out var max).Equals(false))
         {
-            errorEmbed.Embed.WithTitle("The maximum number is not a valid number\nThe highest number I can roll is 1000 and the lowest is 1")
-                .WithColor(Color.Red);
-            return Task.FromResult((0, 0, true, errorEmbed));
+            return Task.FromResult((0, 0, true, GenericEmbedService.ErrorEmbed("The maximum number is not a valid number\nThe highest number I can roll is 1000 and the lowest is 1")));
         }
         if (min > max)
         {
-            errorEmbed.Embed.WithTitle("The minimum number cannot be greater than the maximum number")
-                .WithColor(Color.Red);
-            return Task.FromResult((0, 0, true, errorEmbed));
+            return Task.FromResult((0, 0, true, GenericEmbedService.ErrorEmbed("The minimum number cannot be greater than the maximum number")));
         }
 
-        if (min <= 1000 && max <= 1000) return Task.FromResult<(int min, int max, bool failedValidation, ResponseModel error)>((min, max, false, errorEmbed));
-        errorEmbed.Embed.WithTitle("The minimum or maximum number cannot be greater than 1000")
-            .WithColor(Color.Red);
-        return Task.FromResult((0, 0, true, errorEmbed));
+        if (min <= 1000 && max <= 1000) return Task.FromResult<(int min, int max, bool failedValidation, ResponseModel error)>((min, max, false, new ResponseModel()));
+        return Task.FromResult((0, 0, true, GenericEmbedService.ErrorEmbed("The minimum or maximum number cannot be greater than 1000")));
     }
 }

--- a/src/dotBento.Bot/Commands/SharedCommands/LastFmCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/LastFmCommand.cs
@@ -27,20 +27,14 @@ public sealed class LastFmCommand(
         var lastFmUser = await lastFmService.GetLastFmAsync(userId);
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var response = await lastFmCommands.NowPlaying(lastFmUser.Value.Lastfm1, config.Value.LastFmApiKey);
         if (response.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: " + response.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + response.Error);
         }
 
         var bentoLastFmRecentTracks = response.Value.RecentTracks;
@@ -79,13 +73,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topArtistsResponse =
@@ -93,12 +82,7 @@ public sealed class LastFmCommand(
 
         if (topArtistsResponse.IsFailure)
         {
-            embed.Embed
-                .WithTitle("Error: " + topArtistsResponse.Error)
-                .WithColor(Color.Red);
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + topArtistsResponse.Error);
         }
 
         var topArtists = topArtistsResponse.Value;
@@ -163,13 +147,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topAlbumsResponse =
@@ -177,12 +156,7 @@ public sealed class LastFmCommand(
 
         if (topAlbumsResponse.IsFailure)
         {
-            embed.Embed
-                .WithTitle("Error: " + topAlbumsResponse.Error)
-                .WithColor(Color.Red);
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + topAlbumsResponse.Error);
         }
 
         var topAlbums = topAlbumsResponse.Value;
@@ -244,13 +218,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topTracksResponse =
@@ -258,12 +227,7 @@ public sealed class LastFmCommand(
 
         if (topTracksResponse.IsFailure)
         {
-            embed.Embed
-                .WithTitle("Error: " + topTracksResponse.Error)
-                .WithColor(Color.Red);
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + topTracksResponse.Error);
         }
 
         var topTracks = topTracksResponse.Value;
@@ -327,25 +291,15 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var userInfoResponse = await lastFmCommands.GetUserInfo(lastFmUser.Value.Lastfm1, config.Value.LastFmApiKey);
 
         if (userInfoResponse.IsFailure)
         {
-            embed.Embed
-                .WithTitle("Error: " + userInfoResponse.Error)
-                .WithColor(Color.Red);
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + userInfoResponse.Error);
         }
 
         var userInfo = userInfoResponse.Value;
@@ -390,13 +344,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var recentTracksResponse =
@@ -404,12 +353,7 @@ public sealed class LastFmCommand(
 
         if (recentTracksResponse.IsFailure)
         {
-            embed.Embed
-                .WithTitle("Error: " + recentTracksResponse.Error)
-                .WithColor(Color.Red);
-
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error: " + recentTracksResponse.Error);
         }
 
         var recentTracks = recentTracksResponse.Value;
@@ -523,12 +467,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topArtistsResponse = await lastFmCommands.GetTopArtists(lastFmUser.Value.Lastfm1,
@@ -537,12 +477,7 @@ public sealed class LastFmCommand(
 
         if (topArtistsResponse.IsFailure)
         {
-            result.Embed
-                .WithTitle("Error: " + topArtistsResponse.Error)
-                .WithColor(Color.Red);
-
-            result.ResponseType = ResponseType.Embed;
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + topArtistsResponse.Error);
         }
 
         var topArtists = topArtistsResponse.Value;
@@ -570,12 +505,7 @@ public sealed class LastFmCommand(
 
         if (image.IsFailure)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithTitle("Error: " + image.Error)
-                .WithColor(Color.Red);
-
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + image.Error);
         }
 
         result.Stream = image.Value;
@@ -600,12 +530,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topAlbumsResponse = await lastFmCommands.GetTopAlbums(lastFmUser.Value.Lastfm1,
@@ -614,12 +540,7 @@ public sealed class LastFmCommand(
 
         if (topAlbumsResponse.IsFailure)
         {
-            result.Embed
-                .WithTitle("Error: " + topAlbumsResponse.Error)
-                .WithColor(Color.Red);
-
-            result.ResponseType = ResponseType.Embed;
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + topAlbumsResponse.Error);
         }
 
         var topAlbums = topAlbumsResponse.Value;
@@ -632,12 +553,7 @@ public sealed class LastFmCommand(
 
         if (image.IsFailure)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithTitle("Error: " + image.Error)
-                .WithColor(Color.Red);
-
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + image.Error);
         }
 
         result.Stream = image.Value;
@@ -662,12 +578,8 @@ public sealed class LastFmCommand(
 
         if (lastFmUser.HasNoValue)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error: No Last.fm username saved")
-                .WithDescription("Please save your Last.fm username with either the slash command or the text command");
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: No Last.fm username saved",
+                "Please save your Last.fm username with either the slash command or the text command");
         }
 
         var topTracksResponse = await lastFmCommands.GetTopTracks(lastFmUser.Value.Lastfm1,
@@ -676,12 +588,7 @@ public sealed class LastFmCommand(
 
         if (topTracksResponse.IsFailure)
         {
-            result.Embed
-                .WithTitle("Error: " + topTracksResponse.Error)
-                .WithColor(Color.Red);
-
-            result.ResponseType = ResponseType.Embed;
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + topTracksResponse.Error);
         }
 
         var topTracks = topTracksResponse.Value;
@@ -709,12 +616,7 @@ public sealed class LastFmCommand(
 
         if (image.IsFailure)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithTitle("Error: " + image.Error)
-                .WithColor(Color.Red);
-
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error: " + image.Error);
         }
 
         result.Stream = image.Value;

--- a/src/dotBento.Bot/Commands/SharedCommands/LeaderboardCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/LeaderboardCommand.cs
@@ -4,6 +4,7 @@ using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 using dotBento.Domain.Enums.Leaderboard;
 using dotBento.Infrastructure.Models;
 using dotBento.Infrastructure.Services;
@@ -17,10 +18,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetServerXpLeaderboardAsync(guildId);
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the server leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the server leaderboard.");
 
         var leaderboardUrl = $"{DiscordConstants.WebsiteUrl}/leaderboard/{guildId}";
         return BuildXpPaginator(result.Value, $"Leaderboard for {guildName}", guildIconUrl, leaderboardUrl);
@@ -30,10 +31,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetGlobalXpLeaderboardAsync();
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the global leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the global leaderboard.");
 
         var hiddenUserIds = await userSettingService.GetHiddenGlobalLeaderboardUserIdsAsync();
         var anonymized = result.Value.Select(e => hiddenUserIds.Contains(e.UserId)
@@ -48,10 +49,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetServerBentoLeaderboardAsync(guildId);
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the server bento leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the server bento leaderboard.");
 
         var leaderboardUrl = $"{DiscordConstants.WebsiteUrl}/leaderboard/{guildId}";
         return BuildBentoPaginator(result.Value, $"Bento Leaderboard for {guildName}", guildIconUrl, leaderboardUrl);
@@ -61,10 +62,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetGlobalBentoLeaderboardAsync();
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the global bento leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the global bento leaderboard.");
 
         var hiddenUserIds = await userSettingService.GetHiddenGlobalLeaderboardUserIdsAsync();
         var anonymized = result.Value.Select(e => hiddenUserIds.Contains(e.UserId)
@@ -81,10 +82,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetServerRpsLeaderboardAsync(guildId, type, order);
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the server RPS leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the server RPS leaderboard.");
 
         var typeLabel = type == RpsLeaderboardType.All ? "" : $" ({type})";
         var leaderboardUrl = $"{DiscordConstants.WebsiteUrl}/leaderboard/{guildId}";
@@ -96,10 +97,10 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetGlobalRpsLeaderboardAsync(type, order);
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         if (result.Value.Count == 0)
-            return ErrorEmbed("No users found on the global RPS leaderboard.");
+            return GenericEmbedService.ErrorEmbed("No users found on the global RPS leaderboard.");
 
         var hiddenUserIds = await userSettingService.GetHiddenGlobalLeaderboardUserIdsAsync();
         var anonymized = result.Value.Select(e => hiddenUserIds.Contains(e.UserId)
@@ -116,7 +117,7 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
     {
         var result = await leaderboardService.GetUserLeaderboardSummaryAsync(userId, guildId);
         if (result.IsFailure)
-            return ErrorEmbed(result.Error);
+            return GenericEmbedService.ErrorEmbed(result.Error);
 
         var summary = result.Value;
         var embed = new ResponseModel { ResponseType = ResponseType.Embed };
@@ -241,12 +242,4 @@ public sealed class LeaderboardCommand(LeaderboardService leaderboardService, Us
         return embed;
     }
 
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel { ResponseType = ResponseType.Embed };
-        embed.Embed
-            .WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/SharedCommands/MediaCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/MediaCommand.cs
@@ -161,7 +161,7 @@ public sealed class MediaCommand(
         else
         {
             response.Embed
-                .WithColor(Color.Red)
+                .WithColor(DiscordConstants.ErrorRed)
                 .WithTitle("Failed to fetch media")
                 .WithDescription(error);
         }

--- a/src/dotBento.Bot/Commands/SharedCommands/ReminderCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/ReminderCommand.cs
@@ -3,6 +3,7 @@ using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Commands;
 using Fergun.Interactive;
 
@@ -16,11 +17,7 @@ public sealed class ReminderCommand(ReminderCommands reminderCommands)
         var result = await reminderCommands.CreateReminderAsync(userId, content, date);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         embed.Embed
             .WithColor(Color.Green)
@@ -35,11 +32,7 @@ public sealed class ReminderCommand(ReminderCommands reminderCommands)
         var result = await reminderCommands.DeleteReminderAsync(userId, reminderId);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         embed.Embed
             .WithColor(Color.Green)
@@ -54,11 +47,7 @@ public sealed class ReminderCommand(ReminderCommands reminderCommands)
         var result = await reminderCommands.UpdateReminderAsync(userId, reminderId, newContent, newDate);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var description = $"Reminder with ID `{reminderId}` has been updated.";
         if (newContent != null)
@@ -82,11 +71,7 @@ public sealed class ReminderCommand(ReminderCommands reminderCommands)
         var result = await reminderCommands.GetReminderAsync(userId, reminderId);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var reminder = result.Value;
         embed.Embed
@@ -102,11 +87,7 @@ public sealed class ReminderCommand(ReminderCommands reminderCommands)
         var result = await reminderCommands.GetRemindersAsync(userId);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var reminders = result.Value;
 

--- a/src/dotBento.Bot/Commands/SharedCommands/TagsCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/TagsCommand.cs
@@ -5,6 +5,7 @@ using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Commands;
 using dotBento.Infrastructure.Dto.Tags;
 using Fergun.Interactive;
@@ -18,11 +19,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var embed = new ResponseModel { ResponseType = ResponseType.Embed };
         if (content.MessageContent == null && content.Attachments.Length == 0)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Tag content cannot be empty.\nPlease provide message content or attachment.");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "Tag content cannot be empty.\nPlease provide message content or attachment.");
         }
         var tagContent = string.Empty;
         if (content.MessageContent != null)
@@ -35,20 +32,12 @@ public sealed class TagsCommand(TagCommands tagCommands)
         }
         if (name.Contains(' '))
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Tag name cannot contain spaces.");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "Tag name cannot contain spaces.");
         }
         var result = await tagCommands.CreateTagAsync(userId, guildId, name, tagContent);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
 
         embed.Embed
@@ -63,11 +52,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.DeleteTagAsync(userId, guildId, name, hasMessageEditPerms);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
 
         embed.Embed
@@ -81,21 +66,13 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var embed = new ResponseModel { ResponseType = ResponseType.Embed };
         if (tagContent.MessageContent == null && tagContent.Attachments.Length == 0)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Tag content cannot be empty.\nPlease provide message content or attachment.");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "Tag content cannot be empty.\nPlease provide message content or attachment.");
         }
         var existingTag = await tagCommands.FindTagAsync(guildId, name);
         // TODO: ask the user if they want to create the tag if it doesn't exist
         if (existingTag.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(existingTag.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", existingTag.Error);
         }
         var content = string.Empty;
         if (tagContent.MessageContent != null)
@@ -109,11 +86,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.UpdateTagAsync(userId, guildId, name, content, hasMessageEditPerms);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
 
         embed.Embed
@@ -127,20 +100,12 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var embed = new ResponseModel { ResponseType = ResponseType.Embed };
         if (newName.Contains(' '))
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Tag name cannot contain spaces.");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", "Tag name cannot contain spaces.");
         }
         var result = await tagCommands.RenameTagAsync(userId, guildId, oldName, newName, hasMessageEditPerms);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
 
         embed.Embed
@@ -154,12 +119,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.GetRandomTagAsync(userId, guildId);
         if (result.IsFailure)
         {
-            var errorEmbed = new ResponseModel { ResponseType = ResponseType.Embed };
-            errorEmbed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return errorEmbed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var resultEmbed = new ResponseModel
         {
@@ -175,12 +135,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.FindTagAsync(guildId, name);
         if (result.IsFailure)
         {
-            var errorEmbed = new ResponseModel { ResponseType = ResponseType.Embed };
-            errorEmbed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return errorEmbed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var resultEmbed = new ResponseModel
         {
@@ -214,12 +169,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.FindTagsAsync(guildId, top, authorId);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var tags = result.Value;
 
@@ -262,11 +212,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var result = await tagCommands.FindTagAsync(guildId, name);
         if (result.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(result.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", result.Error);
         }
         var tag = result.Value;
         var description = tag.Content + $"Created by <@{tag.UserId}>";
@@ -295,12 +241,7 @@ public sealed class TagsCommand(TagCommands tagCommands)
         var tagsResults = await tagCommands.SearchTagsAsync(guildId, query);
         if (tagsResults.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(tagsResults.Error);
-            embed.ResponseType = ResponseType.Embed;
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", tagsResults.Error);
         }
         var tags = tagsResults.Value;
         

--- a/src/dotBento.Bot/Commands/SharedCommands/ToolsCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/ToolsCommand.cs
@@ -3,6 +3,7 @@ using dotBento.Bot.Enums;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Commands;
 using dotBento.Infrastructure.Services;
 using dotBento.Infrastructure.Utilities;
@@ -20,13 +21,9 @@ public sealed class ToolsCommand(ImageCommands imageCommands, IOptions<BotEnvCon
         
         if (colourImage.IsFailure)
         {
-            embed.ResponseType = ResponseType.Embed;
-            embed.Embed.WithTitle("Error")
-                .WithDescription(colourImage.Error)
-                .WithColor(Color.Red);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", colourImage.Error);
         }
-        
+
         embed.Stream = colourImage.Value.Image;
         embed.FileName = "colour.png";
 
@@ -62,12 +59,7 @@ public sealed class ToolsCommand(ImageCommands imageCommands, IOptions<BotEnvCon
         
         if (getDominantColorAsync.IsFailure)
         {
-            embed.ResponseType = ResponseType.Embed;
-            embed.Embed
-                .WithTitle("Error")
-                .WithDescription($"Could not get the dominant colour by your provided input: `{url}`")
-                .WithColor(Color.Red);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", $"Could not get the dominant colour by your provided input: `{url}`");
         }
         
         var dominantColor = getDominantColorAsync.Value;
@@ -80,13 +72,9 @@ public sealed class ToolsCommand(ImageCommands imageCommands, IOptions<BotEnvCon
         
         if (colourImage.IsFailure)
         {
-            embed.ResponseType = ResponseType.Embed;
-            embed.Embed.WithTitle("Error")
-                .WithDescription(colourImage.Error)
-                .WithColor(Color.Red);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", colourImage.Error);
         }
-        
+
         embed.Stream = colourImage.Value.Image;
         embed.FileName = "colour.png";
         
@@ -105,20 +93,14 @@ public sealed class ToolsCommand(ImageCommands imageCommands, IOptions<BotEnvCon
 
         if (!ProfileValidationUtilities.TryValidateTimezone(timezoneId))
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Invalid timezone")
-                .WithDescription($"The timezone `{timezoneId}` could not be found. Please use a valid IANA or Windows timezone ID (example: `Europe/Copenhagen`).");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Invalid timezone",
+                $"The timezone `{timezoneId}` could not be found. Please use a valid IANA or Windows timezone ID (example: `Europe/Copenhagen`).");
         }
 
         if (compareTimezoneId != null && !ProfileValidationUtilities.TryValidateTimezone(compareTimezoneId))
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Invalid comparison timezone")
-                .WithDescription($"The timezone `{compareTimezoneId}` could not be found. Please use a valid IANA or Windows timezone ID (example: `Europe/Copenhagen`).");
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Invalid comparison timezone",
+                $"The timezone `{compareTimezoneId}` could not be found. Please use a valid IANA or Windows timezone ID (example: `Europe/Copenhagen`).");
         }
 
         var zone = TimeZoneInfo.FindSystemTimeZoneById(timezoneId);

--- a/src/dotBento.Bot/Commands/SharedCommands/UrbanCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/UrbanCommand.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Discord;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Domain.Extensions;
 using dotBento.Infrastructure.Services.Api;
 
@@ -20,10 +21,9 @@ public sealed class UrbanCommand(UrbanDictionaryService urbanDictionaryService)
         var urbanList = urbanResult?.List;
         if (urbanList == null || urbanList.Count == 0)
         {
-            embed.Embed.WithTitle($"No results found for \"{query}\"")
-                .WithColor(Color.Red)
-                .WithAuthor(embedAuthor);
-            return embed;
+            var errorEmbed = GenericEmbedService.ErrorEmbed($"No results found for \"{query}\"");
+            errorEmbed.Embed.WithAuthor(embedAuthor);
+            return errorEmbed;
         }
 
         var result = urbanList.First();

--- a/src/dotBento.Bot/Commands/SharedCommands/UserCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/UserCommand.cs
@@ -3,6 +3,7 @@ using Discord.WebSocket;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Commands;
 using dotBento.Infrastructure.Services;
 using dotBento.Infrastructure.Utilities;
@@ -44,12 +45,7 @@ public sealed class UserCommand(
         var user = await userService.GetUserAsync((ulong)userId);
         if (user.HasNoValue)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Failed to create or retrieve user from database. Please try again later or contact support.");
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error", "Failed to create or retrieve user from database. Please try again later or contact support.");
         }
         var imageServerHost = config.Value.ImageServer.Url;
         var lastFmApiKey = config.Value.LastFmApiKey;
@@ -58,12 +54,7 @@ public sealed class UserCommand(
 
         if (profile.IsFailure)
         {
-            result.ResponseType = ResponseType.Embed;
-            result.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription("Something went wrong while trying to get the profile. Please try again later. Feel free to contact support if the issue persists.");
-            return result;
+            return GenericEmbedService.ErrorEmbed("Error", "Something went wrong while trying to get the profile. Please try again later. Feel free to contact support if the issue persists.");
         }
         
         result.Stream = profile.Value;

--- a/src/dotBento.Bot/Commands/SharedCommands/WeatherCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/WeatherCommand.cs
@@ -3,6 +3,7 @@ using Discord;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Domain.Extensions;
 using dotBento.Infrastructure.Models.Weather;
 using dotBento.Infrastructure.Services;
@@ -25,11 +26,8 @@ public sealed class WeatherCommand(
             var weather = await weatherService.GetWeatherAsync(userId);
             if (weather.HasNoValue)
             {
-                embed.Embed
-                    .WithColor(Color.Red)
-                    .WithTitle("Error: No city saved or provided")
-                    .WithDescription("You need to provide a city or save one with the weather save command\nFind the weather save command as a slash command or by trying help after calling the weather command.");
-                return embed;
+                return GenericEmbedService.ErrorEmbed("Error: No city saved or provided",
+                    "You need to provide a city or save one with the weather save command\nFind the weather save command as a slash command or by trying help after calling the weather command.");
             }
             city = weather.Value.City;
         } else
@@ -40,11 +38,7 @@ public sealed class WeatherCommand(
         var weatherDataResult = await weatherApiService.GetWeatherForCity(city, config.Value.OpenWeatherApiKey);
         if (weatherDataResult.IsFailure)
         {
-            embed.Embed
-                .WithColor(Color.Red)
-                .WithTitle("Error")
-                .WithDescription(weatherDataResult.Error);
-            return embed;
+            return GenericEmbedService.ErrorEmbed("Error", weatherDataResult.Error);
         }
         var weatherData = weatherDataResult.Value;
         var currentWeather = weatherData.Weather.First();

--- a/src/dotBento.Bot/Commands/SlashCommands/PingSlashCommand.cs
+++ b/src/dotBento.Bot/Commands/SlashCommands/PingSlashCommand.cs
@@ -1,4 +1,3 @@
-using Discord;
 using Discord.Interactions;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
@@ -46,7 +45,7 @@ public sealed class PingSlashCommand(BotDbContext botDbContext, InteractiveServi
             var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
             embed.Embed.WithTitle("\ud83c\udfd3 Pong!")
                 .WithDescription($"**Bento latency** {messageTime} ms\n**Discord latency** {Context.Client.Latency} ms\n**Database** Connection was not established.")
-                .WithColor(Color.Red);
+                .WithColor(DiscordConstants.ErrorRed);
             await Context.SendFollowUpResponse(interactiveService, embed, effectiveHide);
             Context.LogCommandUsed(CommandResponse.Error);
             Log.Error(e, "Ping Slash Command failed");

--- a/src/dotBento.Bot/Commands/SlashCommands/ReminderSlashCommand.cs
+++ b/src/dotBento.Bot/Commands/SlashCommands/ReminderSlashCommand.cs
@@ -1,11 +1,10 @@
 using System.Globalization;
-using Discord;
 using Discord.Interactions;
 using dotBento.Bot.AutoCompleteHandlers;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using Fergun.Interactive;
 
 namespace dotBento.Bot.Commands.SlashCommands;
@@ -25,7 +24,7 @@ public sealed class ReminderSlashCommand(InteractiveService interactiveService, 
         if (convertDate.HasNoValue)
         {
             await Context.SendResponse(interactiveService,
-                ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
+                GenericEmbedService.ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
             return;
         }
         await Context.SendResponse(
@@ -62,7 +61,7 @@ public sealed class ReminderSlashCommand(InteractiveService interactiveService, 
             {
                 await Context.SendResponse(
                     interactiveService,
-                    ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."),
+                    GenericEmbedService.ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."),
                     true);
                 return;
             }
@@ -104,11 +103,4 @@ public sealed class ReminderSlashCommand(InteractiveService interactiveService, 
         );
     }
     
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/SlashCommands/ServerSlashCommand.cs
+++ b/src/dotBento.Bot/Commands/SlashCommands/ServerSlashCommand.cs
@@ -4,9 +4,9 @@ using Discord.Interactions;
 using Discord.WebSocket;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Services;
 using Fergun.Interactive;
 
@@ -26,10 +26,7 @@ public sealed class ServerSlashCommand(InteractiveService interactiveService, Se
         var guildMember = Context.Guild.Users.Single(guildUser => guildUser.Id == user.Id).AsMaybe();
         if (guildMember.HasNoValue)
         {
-            var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-            embed.Embed.WithTitle($"The user you inserted is not in this server")
-                .WithColor(Color.Red);
-            await Context.SendResponse(interactiveService, embed, true);
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"), true);
             return;
         }
         await Context.SendResponse(interactiveService, await serverCommand.UserServerCommand(guildMember.Value), hide ?? await userSettingService.ShouldHideCommandsAsync((long)Context.User.Id));

--- a/src/dotBento.Bot/Commands/SlashCommands/ToolsSlashCommand.cs
+++ b/src/dotBento.Bot/Commands/SlashCommands/ToolsSlashCommand.cs
@@ -2,9 +2,9 @@ using Discord;
 using Discord.Interactions;
 using dotBento.Bot.AutoCompleteHandlers;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Services;
 using Fergun.Interactive;
 
@@ -33,7 +33,7 @@ public sealed class ToolsSlashCommand(InteractiveService interactiveService, Too
         var effectiveHide = hide ?? await userSettingService.ShouldHideCommandsAsync((long)Context.User.Id);
         if (string.IsNullOrWhiteSpace(url))
         {
-            await Context.SendResponse(interactiveService, ErrorEmbed("Please provide a URL or attach an image to the command."), effectiveHide);
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Please provide a URL or attach an image to the command."), effectiveHide);
             return;
         }
 
@@ -55,11 +55,4 @@ public sealed class ToolsSlashCommand(InteractiveService interactiveService, Too
             await toolsCommand.GetTimezone(timezone, compare, Context.User.Id),
             hide ?? await userSettingService.ShouldHideCommandsAsync((long)Context.User.Id));
 
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/TextCommands/LastFmTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/LastFmTextCommand.cs
@@ -1,12 +1,11 @@
 using CSharpFunctionalExtensions;
-using Discord;
 using Discord.Commands;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Utilities;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
@@ -79,7 +78,7 @@ public sealed class LastFmTextCommand(
                         }
                         else
                         {
-                            await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                             return;
                         }
                     }
@@ -87,7 +86,7 @@ public sealed class LastFmTextCommand(
                 var userForUserCmd23 = Context.Guild.GetUser(getUserForUserCmd23.Id).AsMaybe();
                 if (userForUserCmd23.HasNoValue)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                     return;
                 }
                 var guildMemberForUserCmd23 = userForUserCmd23.Value;
@@ -113,7 +112,7 @@ public sealed class LastFmTextCommand(
                         }
                         else
                         {
-                            await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                             return;
                         }
                     }
@@ -121,7 +120,7 @@ public sealed class LastFmTextCommand(
                 var userForUserCmd2 = Context.Guild.GetUser(getUserForUserCmd2.Id).AsMaybe();
                 if (userForUserCmd2.HasNoValue)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                     return;
                 }
                 var guildMemberForUserCmd2 = userForUserCmd2.Value;
@@ -152,7 +151,7 @@ public sealed class LastFmTextCommand(
                         }
                         else
                         {
-                            await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                             return;
                         }
                     }
@@ -160,7 +159,7 @@ public sealed class LastFmTextCommand(
                 var userForUserCmd = Context.Guild.GetUser(getUserForUserCmd.Id).AsMaybe();
                 if (userForUserCmd.HasNoValue)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
                     return;
                 }
                 var guildMemberForUserCmd = userForUserCmd.Value;
@@ -176,7 +175,7 @@ public sealed class LastFmTextCommand(
 
         if (args.Length > 1 && period == null)
         {
-            await Context.SendResponse(interactiveService, ErrorEmbed($"Your time period {args[1]} is not valid"));
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed($"Your time period {args[1]} is not valid"));
             return;
         }
 
@@ -196,7 +195,7 @@ public sealed class LastFmTextCommand(
                 else
                 {
                     // TODO: insert env var for name or something
-                    await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not recognised by Bento"));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not recognised by Bento"));
                     return;
                 }
             }
@@ -205,7 +204,7 @@ public sealed class LastFmTextCommand(
         var user = Context.Guild.GetUser(getUser.Id).AsMaybe();
         if (user.HasNoValue)
         {
-            await Context.SendResponse(interactiveService, ErrorEmbed("The user you inserted is not in this server"));
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
             return;
         }
             
@@ -255,7 +254,7 @@ public sealed class LastFmTextCommand(
                         size = "6x6";
                         break;
                     default:
-                        await Context.SendResponse(interactiveService, ErrorEmbed("Invalid size for collage. Please use `lastfm help` for a list of commands."));
+                        await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Invalid size for collage. Please use `lastfm help` for a list of commands."));
                         return;
                 }
                 
@@ -271,23 +270,16 @@ public sealed class LastFmTextCommand(
                         await Context.SendResponse(interactiveService, await lastFmCommand.GetTopTracksCollage((long)guildMember.Id, userAvatar, period ?? "Overall", size));
                         break;
                     default:
-                        await Context.SendResponse(interactiveService, ErrorEmbed("Invalid type. Please use `lastfm help` for a list of commands."));
+                        await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Invalid type. Please use `lastfm help` for a list of commands."));
                         break;
                 }
                 break;
             }
             default: 
                 await Context.SendResponse(interactiveService,
-                    ErrorEmbed("Invalid command. Please use `lastfm help` for a list of commands."));
+                    GenericEmbedService.ErrorEmbed("Invalid command. Please use `lastfm help` for a list of commands."));
                 break;
         }
     }
 
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/TextCommands/LeaderboardTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/LeaderboardTextCommand.cs
@@ -7,6 +7,7 @@ using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Domain.Enums.Leaderboard;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
@@ -81,7 +82,7 @@ public sealed class LeaderboardTextCommand(
                 break;
 
             default:
-                await Context.SendResponse(interactiveService, ErrorEmbed(
+                await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed(
                     "Invalid subcommand. Use: `leaderboard [global|bento|bento global|rps|rps global|user @someone]`"));
                 break;
         }
@@ -132,14 +133,14 @@ public sealed class LeaderboardTextCommand(
                 var resolvedUser = Context.Client.GetUser(userId);
                 if (resolvedUser == null)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("User not found."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("User not found."));
                     return;
                 }
                 user = resolvedUser;
             }
             else
             {
-                await Context.SendResponse(interactiveService, ErrorEmbed("Invalid user. Mention a user or provide a user ID."));
+                await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Invalid user. Mention a user or provide a user ID."));
                 return;
             }
         }
@@ -158,11 +159,4 @@ public sealed class LeaderboardTextCommand(
                 (long)user.Id, (long)guild.Id, displayName, avatarUrl, guild.Name));
     }
 
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel { ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/TextCommands/MemberTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/MemberTextCommand.cs
@@ -1,13 +1,12 @@
 using CSharpFunctionalExtensions;
-using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
 
@@ -32,10 +31,7 @@ public sealed class MemberTextCommand(
         var guildMember = Context.Guild.Users.Single(guildUser => guildUser.Id == user.Id).AsMaybe();
         if (guildMember.HasNoValue)
         {
-            var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-            embed.Embed.WithTitle($"The user you inserted is not in this server")
-                .WithColor(Color.Red);
-            await Context.SendResponse(interactiveService, embed);
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("The user you inserted is not in this server"));
             return;
         }
         await Context.SendResponse(interactiveService, await serverCommand.UserServerCommand(guildMember.Value));

--- a/src/dotBento.Bot/Commands/TextCommands/ReminderTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/ReminderTextCommand.cs
@@ -1,11 +1,10 @@
-using Discord;
 using Discord.Commands;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
 
@@ -33,7 +32,7 @@ public sealed class ReminderTextCommand(
         if (string.IsNullOrWhiteSpace(input))
         {
             await Context.SendResponse(interactiveService,
-                ErrorEmbed(
+                GenericEmbedService.ErrorEmbed(
                     "Please provide an argument to the command. You can check the usage of the command with the `remind help` command."));
             return;
         }
@@ -50,7 +49,7 @@ public sealed class ReminderTextCommand(
                 if (args.Length < 3)
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Please provide a date and content for the reminder."));
+                        GenericEmbedService.ErrorEmbed("Please provide a date and content for the reminder."));
                     return;
                 }
                 
@@ -58,7 +57,7 @@ public sealed class ReminderTextCommand(
                 if (date.HasNoValue)
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
+                        GenericEmbedService.ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
                     return;
                 }
 
@@ -70,14 +69,14 @@ public sealed class ReminderTextCommand(
                 if (args.Length < 2)
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Please provide a reminder ID."));
+                        GenericEmbedService.ErrorEmbed("Please provide a reminder ID."));
                     return;
                 }
 
                 if (!int.TryParse(args[1], out var id))
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
+                        GenericEmbedService.ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
                     return;
                 }
 
@@ -88,14 +87,14 @@ public sealed class ReminderTextCommand(
                 if (args.Length < 4)
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Please provide a reminder ID, new date, and new content."));
+                        GenericEmbedService.ErrorEmbed("Please provide a reminder ID, new date, and new content."));
                     return;
                 }
 
                 if (!int.TryParse(args[1], out var reminderId))
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
+                        GenericEmbedService.ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
                     return;
                 }
                 
@@ -111,7 +110,7 @@ public sealed class ReminderTextCommand(
                     if (newDate.HasNoValue)
                     {
                         await Context.SendResponse(interactiveService,
-                            ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
+                            GenericEmbedService.ErrorEmbed("Invalid date. Please provide a valid date in the format `YYYY-MM-DDThh:mm[{+|-}hh:mm]` (e.g. 2022-12-31T23:59+00:00)."));
                         return;
                     }
 
@@ -128,14 +127,14 @@ public sealed class ReminderTextCommand(
                 if (args.Length < 2)
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Please provide a reminder ID."));
+                        GenericEmbedService.ErrorEmbed("Please provide a reminder ID."));
                     return;
                 }
 
                 if (!int.TryParse(args[1], out var infoReminderId))
                 {
                     await Context.SendResponse(interactiveService,
-                        ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
+                        GenericEmbedService.ErrorEmbed("Invalid reminder ID. Please provide a valid reminder ID."));
                     return;
                 }
 
@@ -144,17 +143,10 @@ public sealed class ReminderTextCommand(
                 break;
             default:
                 await Context.SendResponse(interactiveService,
-                    ErrorEmbed(
+                    GenericEmbedService.ErrorEmbed(
                         "Invalid command. You can check the usage of the command with the `remind help` command."));
                 break;
         }
     }
     
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/TextCommands/RpsTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/RpsTextCommand.cs
@@ -1,11 +1,10 @@
-using Discord;
 using Discord.Commands;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Domain.Enums.Games;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
@@ -26,11 +25,8 @@ public sealed class RpsTextCommand(
         _ = Context.Channel.TriggerTypingAsync();
         if (!Enum.TryParse<RpsGameChoice>(userChoice, true, out var rpsChoice))
         {
-            var errorEmbed = new ResponseModel{ ResponseType = ResponseType.Embed };
-            errorEmbed.Embed.WithTitle("Error \ud83e\udea8 \ud83e\uddfb \u2702\ufe0f")
-                .WithDescription("Please choose between rock \ud83e\udea8, paper \ud83e\uddfb or scissors \u2702\ufe0f")
-                .WithColor(Color.Red);
-            await Context.SendResponse(interactiveService, errorEmbed);
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Error \ud83e\udea8 \ud83e\uddfb \u2702\ufe0f",
+                "Please choose between rock \ud83e\udea8, paper \ud83e\uddfb or scissors \u2702\ufe0f"));
             return;
         }
         await Context.SendResponse(interactiveService, await gameCommand.RpsCommand(rpsChoice, (long)Context.User.Id));

--- a/src/dotBento.Bot/Commands/TextCommands/TagsTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/TagsTextCommand.cs
@@ -1,13 +1,12 @@
 using CSharpFunctionalExtensions;
-using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Dto.Tags;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
@@ -42,7 +41,7 @@ public sealed class TagsTextCommand(
     {
         if (string.IsNullOrWhiteSpace(input))
         {
-            await Context.SendResponse(interactiveService, ErrorEmbed("Please provide an argument to the command. You can check the usage of the command with the `tags help` command."));
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Please provide an argument to the command. You can check the usage of the command with the `tags help` command."));
             return;
         }
         
@@ -60,7 +59,7 @@ public sealed class TagsTextCommand(
             case "add":
                 if (args.Length < 3)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags create <tag name> <tag content>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags create <tag name> <tag content>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var createName = args[1];
@@ -74,7 +73,7 @@ public sealed class TagsTextCommand(
             case "get":
                 if (args.Length < 2)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags get <tag name>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags get <tag name>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var getName = args[1];
@@ -86,7 +85,7 @@ public sealed class TagsTextCommand(
             case "search":
                 if (args.Length < 2)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags search <tag name>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags search <tag name>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var query = string.Join(' ', args.Skip(1));
@@ -99,7 +98,7 @@ public sealed class TagsTextCommand(
             case "remove":
                 if (args.Length < 2)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags delete <tag name>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags delete <tag name>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var deleteName = args[1];
@@ -129,7 +128,7 @@ public sealed class TagsTextCommand(
             case "update":
                 if (args.Length < 3)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags update <tag name> <new tag content>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags update <tag name> <new tag content>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var updateName = args[1];
@@ -143,7 +142,7 @@ public sealed class TagsTextCommand(
             case "info":
                 if (args.Length < 2)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags info <tag name>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags info <tag name>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var infoName = args[1];
@@ -155,7 +154,7 @@ public sealed class TagsTextCommand(
             case "rename":
                 if (args.Length < 3)
                 {
-                    await Context.SendResponse(interactiveService, ErrorEmbed("Usage: tags rename <tag name> <new tag name>. You can check the usage of the command with the `tags help` command."));
+                    await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Usage: tags rename <tag name> <new tag name>. You can check the usage of the command with the `tags help` command."));
                     return;
                 }
                 var oldName = args[1];
@@ -178,16 +177,9 @@ public sealed class TagsTextCommand(
                     await Context.SendResponse(interactiveService, tag.Value);
                     break;
                 }
-                await Context.SendResponse(interactiveService, ErrorEmbed("Invalid command. Please check the usage of the command with the `tags help` command."));
+                await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Invalid command. Please check the usage of the command with the `tags help` command."));
                 break;
         }
     }
     
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Commands/TextCommands/ToolsTextCommand.cs
+++ b/src/dotBento.Bot/Commands/TextCommands/ToolsTextCommand.cs
@@ -1,11 +1,10 @@
-using Discord;
 using Discord.Commands;
 using dotBento.Bot.Attributes;
 using dotBento.Bot.Commands.SharedCommands;
-using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Services;
 using dotBento.Infrastructure.Utilities;
 using Fergun.Interactive;
 using Microsoft.Extensions.Options;
@@ -45,7 +44,7 @@ public sealed class ToolsTextCommand(
         
         if (string.IsNullOrWhiteSpace(url))
         {
-            await Context.SendResponse(interactiveService, ErrorEmbed("Please provide a URL or attach an image to the command."));
+            await Context.SendResponse(interactiveService, GenericEmbedService.ErrorEmbed("Please provide a URL or attach an image to the command."));
             return;
         }
         
@@ -87,11 +86,4 @@ public sealed class ToolsTextCommand(
             await toolsCommand.GetTimezone(timezoneId, compareId, Context.User.Id));
     }
 
-    private static ResponseModel ErrorEmbed(string error)
-    {
-        var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        embed.Embed.WithTitle(error)
-            .WithColor(Color.Red);
-        return embed;
-    }
 }

--- a/src/dotBento.Bot/Resources/DiscordConstants.cs
+++ b/src/dotBento.Bot/Resources/DiscordConstants.cs
@@ -7,7 +7,9 @@ namespace dotBento.Bot.Resources;
 public sealed class DiscordConstants
 {
     public static Color BentoYellow = new(253, 224, 71);
-    
+
+    public static Color ErrorRed = new(255, 0, 0);
+
     public static Color LastFmColorRed = new(186, 0, 0);
 
     public static Color WarningColorOrange = new(255, 174, 66);

--- a/src/dotBento.Bot/Services/GenericEmbedService.cs
+++ b/src/dotBento.Bot/Services/GenericEmbedService.cs
@@ -2,12 +2,23 @@ using System.Text;
 using Discord;
 using Discord.Commands;
 using dotBento.Bot.Attributes;
+using dotBento.Bot.Enums;
+using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
 
 namespace dotBento.Bot.Services;
 
 public static class GenericEmbedService
 {
+    public static ResponseModel ErrorEmbed(string title, string? description = null)
+    {
+        var embed = new ResponseModel { ResponseType = ResponseType.Embed };
+        embed.Embed.WithColor(DiscordConstants.ErrorRed).WithTitle(title);
+        if (description is not null)
+            embed.Embed.WithDescription(description);
+        return embed;
+    }
+
     public static void HelpResponse(this EmbedBuilder embed, CommandInfo commandInfo, string prefix, string username)
     {
         embed.WithColor(DiscordConstants.InformationColorBlue);


### PR DESCRIPTION
## Summary

- Adds `ErrorEmbed(title, description?)` factory method to `GenericEmbedService` as the single source of truth for error embed construction
- Adds `ErrorRed` color constant to `DiscordConstants` (replacing scattered `Color.Red`, `new Color(0xFF0000)`, `new Color(255, 0, 0)` literals)
- Removes 9 duplicate private `ErrorEmbed` methods across command files
- Replaces ~40 inline error embed constructions across 25 files with the centralised helper

Closes #409

## Test plan

- [ ] Build passes with 0 errors (`dotnet build dotBento.sln`)
- [ ] Colour-check commands (`/tools colour`, `/tools dominantcolour`) still show red embeds on invalid input
- [ ] Reminder commands show error embeds for invalid input
- [ ] Tags commands show error embeds on failure
- [ ] Ephemeral detection (slash commands that check `embed.Embed.Color == Color.Red`) still works — `DiscordConstants.ErrorRed` is value-equal to `Color.Red` (255,0,0)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)