### PR TITLE
fix: stream media responses to reduce memory spikes

### DIFF
--- a/src/dotBento.Bot/Extensions/CommandContextExtensions.cs
+++ b/src/dotBento.Bot/Extensions/CommandContextExtensions.cs
@@ -69,7 +69,8 @@ public static class CommandContextExtensions
                     TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
                 break;
             case ResponseType.ImageWithEmbed:
-                var imageEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
+            {
+                await using var imageEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
                 var imageEmbedFilename = response.FileName ?? throw new InvalidOperationException("FileName required for ImageWithEmbed");
                 await context.Client.Rest.SendMessageAsync(context.Message.ChannelId, new MessageProperties()
                     .AddAttachments(new AttachmentProperties(
@@ -77,17 +78,18 @@ public static class CommandContextExtensions
                         imageEmbedStream))
                     .AddEmbeds(response.Embed)
                     .WithComponents(response.Components));
-                await imageEmbedStream.DisposeAsync();
                 break;
+            }
             case ResponseType.ImageOnly:
-                var imageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
+            {
+                await using var imageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
                 var imageOnlyFilename = response.FileName ?? throw new InvalidOperationException("FileName required for ImageOnly");
                 await context.Client.Rest.SendMessageAsync(context.Message.ChannelId, new MessageProperties()
                     .AddAttachments(new AttachmentProperties(
                         (response.Spoiler ? "SPOILER_" : "") + imageOnlyFilename + ".png",
                         imageOnlyStream)));
-                await imageOnlyStream.DisposeAsync();
                 break;
+            }
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/src/dotBento.Bot/Extensions/InteractionContextExtensions.cs
+++ b/src/dotBento.Bot/Extensions/InteractionContextExtensions.cs
@@ -88,7 +88,8 @@ public static class InteractionContextExtensions
                     ephemeral: ephemeral);
                 break;
             case ResponseType.ImageWithEmbed:
-                var imageWithEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
+            {
+                await using var imageWithEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
                 var imageWithEmbedFilename = response.FileName ?? throw new InvalidOperationException("FileName required for ImageWithEmbed");
                 await context.Interaction.SendResponseAsync(InteractionCallback.Message(
                     new InteractionMessageProperties()
@@ -98,10 +99,11 @@ public static class InteractionContextExtensions
                         .WithEmbeds([response.Embed])
                         .WithFlags(flags)
                         .WithComponents(response.Components)));
-                await imageWithEmbedStream.DisposeAsync();
                 break;
+            }
             case ResponseType.ImageOnly:
-                var imageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
+            {
+                await using var imageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
                 var imageOnlyFilename = response.FileName ?? throw new InvalidOperationException("FileName required for ImageOnly");
                 await context.Interaction.SendResponseAsync(InteractionCallback.Message(
                     new InteractionMessageProperties()
@@ -109,10 +111,11 @@ public static class InteractionContextExtensions
                             (response.Spoiler ? "SPOILER_" : "") + imageOnlyFilename,
                             imageOnlyStream))
                         .WithFlags(flags)));
-                await imageOnlyStream.DisposeAsync();
                 break;
+            }
             case ResponseType.FileWithEmbed:
-                var fileWithEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for FileWithEmbed");
+            {
+                await using var fileWithEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for FileWithEmbed");
                 var fileWithEmbedFilename = response.FileName ?? throw new InvalidOperationException("FileName required for FileWithEmbed");
                 await context.Interaction.SendResponseAsync(InteractionCallback.Message(
                     new InteractionMessageProperties()
@@ -122,8 +125,8 @@ public static class InteractionContextExtensions
                         .WithEmbeds([response.Embed])
                         .WithFlags(flags)
                         .WithComponents(response.Components)));
-                await fileWithEmbedStream.DisposeAsync();
                 break;
+            }
             default:
                 throw new ArgumentOutOfRangeException();
         }
@@ -162,7 +165,8 @@ public static class InteractionContextExtensions
                     ephemeral: ephemeral);
                 break;
             case ResponseType.ImageWithEmbed:
-                var followupImageEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
+            {
+                await using var followupImageEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageWithEmbed");
                 var followupImageEmbedFilename = (response.FileName ?? throw new InvalidOperationException("FileName required for ImageWithEmbed")).ReplaceInvalidChars().TruncateLongString(60);
                 await context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
                     .AddAttachments(new AttachmentProperties(
@@ -171,20 +175,22 @@ public static class InteractionContextExtensions
                     .WithEmbeds([response.Embed])
                     .WithFlags(flags)
                     .WithComponents(response.Components));
-                await followupImageEmbedStream.DisposeAsync();
                 break;
+            }
             case ResponseType.ImageOnly:
-                var followupImageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
+            {
+                await using var followupImageOnlyStream = response.Stream ?? throw new InvalidOperationException("Stream required for ImageOnly");
                 var followupImageOnlyFilename = response.FileName ?? throw new InvalidOperationException("FileName required for ImageOnly");
                 await context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
                     .AddAttachments(new AttachmentProperties(
                         (response.Spoiler ? "SPOILER_" : "") + followupImageOnlyFilename,
                         followupImageOnlyStream))
                     .WithFlags(flags));
-                await followupImageOnlyStream.DisposeAsync();
                 break;
+            }
             case ResponseType.FileWithEmbed:
-                var followupFileEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for FileWithEmbed");
+            {
+                await using var followupFileEmbedStream = response.Stream ?? throw new InvalidOperationException("Stream required for FileWithEmbed");
                 var followupFileEmbedFilename = response.FileName ?? throw new InvalidOperationException("FileName required for FileWithEmbed");
                 await context.Interaction.SendFollowupMessageAsync(new InteractionMessageProperties()
                     .AddAttachments(new AttachmentProperties(
@@ -193,8 +199,8 @@ public static class InteractionContextExtensions
                     .WithEmbeds([response.Embed])
                     .WithFlags(flags)
                     .WithComponents(response.Components));
-                await followupFileEmbedStream.DisposeAsync();
                 break;
+            }
             default:
                 throw new ArgumentOutOfRangeException();
         }

--- a/src/dotBento.Infrastructure/Services/Api/BentoMediaServerService.cs
+++ b/src/dotBento.Infrastructure/Services/Api/BentoMediaServerService.cs
@@ -60,11 +60,23 @@ public sealed class BentoMediaServerService(HttpClient httpClient)
 
         try
         {
-            using var response = await httpClient.SendAsync(request);
+            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             if (!response.IsSuccessStatusCode)
+            {
+                response.Dispose();
                 return Result.Failure<Stream>($"Proxy returned HTTP {(int)response.StatusCode}");
-            var bytes = await response.Content.ReadAsByteArrayAsync();
-            return Result.Success<Stream>(new MemoryStream(bytes));
+            }
+
+            try
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                return Result.Success<Stream>(new HttpResponseMessageStream(response, stream));
+            }
+            catch
+            {
+                response.Dispose();
+                throw;
+            }
         }
         catch (Exception ex)
         {

--- a/src/dotBento.Infrastructure/Services/Api/HttpResponseMessageStream.cs
+++ b/src/dotBento.Infrastructure/Services/Api/HttpResponseMessageStream.cs
@@ -1,0 +1,80 @@
+namespace dotBento.Infrastructure.Services.Api;
+
+internal sealed class HttpResponseMessageStream(HttpResponseMessage response, Stream innerStream) : Stream
+{
+    private bool _disposed;
+
+    public override bool CanRead => !_disposed && innerStream.CanRead;
+    public override bool CanSeek => !_disposed && innerStream.CanSeek;
+    public override bool CanWrite => false;
+    public override long Length => innerStream.Length;
+
+    public override long Position
+    {
+        get => innerStream.Position;
+        set => innerStream.Position = value;
+    }
+
+    public override void Flush() => innerStream.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) =>
+        innerStream.FlushAsync(cancellationToken);
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        innerStream.Read(buffer, offset, count);
+
+    public override int Read(Span<byte> buffer) =>
+        innerStream.Read(buffer);
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+        innerStream.ReadAsync(buffer, cancellationToken);
+
+    public override long Seek(long offset, SeekOrigin origin) =>
+        innerStream.Seek(offset, origin);
+
+    public override void SetLength(long value) =>
+        throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) =>
+        throw new NotSupportedException();
+
+    public override void Write(ReadOnlySpan<byte> buffer) =>
+        throw new NotSupportedException();
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+        throw new NotSupportedException();
+
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                innerStream.Dispose();
+                response.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        if (!_disposed)
+        {
+            await innerStream.DisposeAsync();
+            response.Dispose();
+            _disposed = true;
+        }
+
+        await base.DisposeAsync();
+    }
+}

--- a/src/dotBento.Infrastructure/Services/Api/SushiiImageServerService.cs
+++ b/src/dotBento.Infrastructure/Services/Api/SushiiImageServerService.cs
@@ -20,12 +20,23 @@ public sealed class SushiiImageServerService(HttpClient httpClient)
 
         request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
-        using var response = await httpClient.SendAsync(request);
+        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
         if (!response.IsSuccessStatusCode)
+        {
+            response.Dispose();
             return Result.Failure<Stream>("Could not get image from Sushii Image Server");
+        }
 
-        var bytes = await response.Content.ReadAsByteArrayAsync();
-        return Result.Success<Stream>(new MemoryStream(bytes));
+        try
+        {
+            var stream = await response.Content.ReadAsStreamAsync();
+            return Result.Success<Stream>(new HttpResponseMessageStream(response, stream));
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
     }
 }

--- a/src/dotBento.Infrastructure/Services/TagService.cs
+++ b/src/dotBento.Infrastructure/Services/TagService.cs
@@ -161,19 +161,26 @@ public sealed class TagService(
     public async Task<List<Tag>> SearchTagsByCommandAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
-        return await context.Tags
-            .Where(x => x.GuildId == guildId && EF.Functions.ILike(x.Command, $"%{query}%"))
-            .ToListAsync();
+        var tags = context.Tags.Where(x => x.GuildId == guildId);
+
+        return IsNpgsql(context)
+            ? await tags.Where(x => EF.Functions.ILike(x.Command, $"%{query}%")).ToListAsync()
+            : await tags.Where(x => x.Command.ToLower().Contains(query.ToLower())).ToListAsync();
     }
 
     // TODO: use cache for search
     public async Task<List<Tag>> SearchTagsByContentAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
-        return await context.Tags
-            .Where(x => x.GuildId == guildId && EF.Functions.ILike(x.Content, $"%{query}%"))
-            .ToListAsync();
+        var tags = context.Tags.Where(x => x.GuildId == guildId);
+
+        return IsNpgsql(context)
+            ? await tags.Where(x => EF.Functions.ILike(x.Content, $"%{query}%")).ToListAsync()
+            : await tags.Where(x => x.Content.ToLower().Contains(query.ToLower())).ToListAsync();
     }
+
+    private static bool IsNpgsql(DbContext context) =>
+        context.Database.ProviderName?.Contains("Npgsql", StringComparison.OrdinalIgnoreCase) == true;
 
     private void InvalidateTagCache(long guildId, string name)
     {

--- a/src/dotBento.Infrastructure/Services/UserService.cs
+++ b/src/dotBento.Infrastructure/Services/UserService.cs
@@ -90,9 +90,9 @@ public sealed class UserService(IMemoryCache cache,
     public async Task<Maybe<int>> GetTotalDiscordUserCountAsync()
     {
         await using var db = await contextFactory.CreateDbContextAsync();
-        var memberCount = db.Guilds
+        var memberCount = await db.Guilds
             .AsQueryable()
-            .SumAsync(s => s.MemberCount).Result;
+            .SumAsync(s => s.MemberCount);
 
         return memberCount.AsMaybe();
     }

--- a/src/dotBento.Infrastructure/Utilities/ProfileValidationUtilities.cs
+++ b/src/dotBento.Infrastructure/Utilities/ProfileValidationUtilities.cs
@@ -8,7 +8,7 @@ public static class ProfileValidationUtilities
     {
         if (string.IsNullOrWhiteSpace(url)) return false;
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
-        return uri.Scheme is "https";
+        return uri.Scheme is "http" or "https";
     }
 
     public static string? NormalizeHex(string hex)

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using dotBento.Infrastructure.Services.Api;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Services.Api;
+
+public sealed class StreamingApiServiceTests
+{
+    [Fact]
+    public async Task BentoMediaProxyAsync_ReturnsStreamWithoutBufferingResponseBody()
+    {
+        var contentStream = new CountingStream(new byte[1024 * 1024]);
+        using var httpClient = CreateHttpClient(contentStream);
+        var service = new BentoMediaServerService(httpClient);
+
+        var result = await service.ProxyAsync("https://media.example", "https://cdn.example/video.mp4");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, contentStream.ReadCount);
+
+        var buffer = new byte[1024];
+        var read = await result.Value.ReadAsync(buffer.AsMemory(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(buffer.Length, read);
+        Assert.True(contentStream.ReadCount > 0);
+
+        await result.Value.DisposeAsync();
+        Assert.True(contentStream.IsDisposed);
+    }
+
+    [Fact]
+    public async Task SushiiImageServer_ReturnsStreamWithoutBufferingResponseBody()
+    {
+        var contentStream = new CountingStream(new byte[1024 * 1024]);
+        using var httpClient = CreateHttpClient(contentStream);
+        var service = new SushiiImageServerService(httpClient);
+
+        var result = await service.GetSushiiImage("https://image.example/render", "<html></html>", 600, 400);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0, contentStream.ReadCount);
+
+        var buffer = new byte[1024];
+        var read = await result.Value.ReadAsync(buffer.AsMemory(), TestContext.Current.CancellationToken);
+
+        Assert.Equal(buffer.Length, read);
+        Assert.True(contentStream.ReadCount > 0);
+
+        await result.Value.DisposeAsync();
+        Assert.True(contentStream.IsDisposed);
+    }
+
+    private static HttpClient CreateHttpClient(Stream contentStream)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StreamContent(contentStream)
+            });
+
+        return new HttpClient(mockHandler.Object);
+    }
+
+    private sealed class CountingStream(byte[] buffer) : MemoryStream(buffer)
+    {
+        public int ReadCount { get; private set; }
+        public bool IsDisposed { get; private set; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ReadCount++;
+            return base.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            ReadCount++;
+            return base.Read(buffer);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ReadCount++;
+            return base.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ReadCount++;
+            return base.ReadAsync(buffer, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            await base.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stream Sushii image server and bento media proxy responses instead of buffering the full response body into managed byte arrays
- dispose response-backed upload streams reliably after Discord sends, including failure paths
- remove a blocking async database call in metrics collection
- align profile URL validation with existing HTTP/HTTPS test expectations
- make tag search tests provider-neutral while preserving Npgsql ILIKE in production

## Why
The memory graph shows sharp peaks that return to baseline, which points more to transient allocation pressure than a classic retained-object leak. The media/image paths previously called ReadAsByteArrayAsync() and wrapped the entire response in a MemoryStream before sending to Discord. Large proxied videos or rendered images could therefore allocate the whole payload in managed memory at once, causing high dotnet_total_memory_bytes spikes until GC caught up.

This PR keeps those response bodies as streams so the bot does not need to hold full media payloads in managed memory.

## Verification
- dotnet test tests/dotBento.Infrastructure.Tests --no-restore -v:minimal (builds, but dotnet test reports no tests due xUnit v3 discovery in this repo)
- dotnet tests/dotBento.Infrastructure.Tests/bin/Debug/net10.0/dotBento.Infrastructure.Tests.dll: Total 123, Failed 0
- dotnet tests/dotBento.Bot.Tests/bin/Debug/net10.0/dotBento.Bot.Tests.dll: Total 76, Failed 0
- dotnet tests/dotBento.WebApi.Tests/bin/Debug/net10.0/dotBento.WebApi.Tests.dll: Total 35, Failed 0