### PR TITLE
fix: reduce bot memory pressure

### DIFF
--- a/src/dotBento.Bot/AutoCompleteHandlers/SearchTagsAutoComplete.cs
+++ b/src/dotBento.Bot/AutoCompleteHandlers/SearchTagsAutoComplete.cs
@@ -11,25 +11,12 @@ public sealed class SearchTagsAutoComplete(TagCommands tagCommands) : Autocomple
     public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context,
         IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
     {
-        var results = new List<string>();
-        var tags = await tagCommands.FindTagsAsync((long)context.Guild.Id, true, Maybe<long>.None);
-        if (tags.IsFailure)
-        {
-            return await Task.FromResult(AutocompletionResult.FromSuccess(results.Select(s => new AutocompleteResult(s, s))));
-        }
-        
-        if (autocompleteInteraction.Data?.Current?.Value == null ||
-            string.IsNullOrWhiteSpace(autocompleteInteraction.Data?.Current?.Value.ToString()))
-        {
-            results.ReplaceOrAddToList(tags.Value.Select(s => s.Command));
-        }
-        else
-        {
-            var searchValue = autocompleteInteraction.Data.Current.Value.ToString();
-            results.ReplaceOrAddToList(tags.Value.Where(x => x.Command.StartsWith(searchValue ?? "")).Select(s => s.Command));
-        }
+        var searchValue = autocompleteInteraction.Data?.Current?.Value?.ToString();
+        var results = await tagCommands.FindTagNamesForAutocompleteAsync(
+            (long)context.Guild.Id,
+            Maybe<long>.None,
+            searchValue);
 
-        return await Task.FromResult(
-            AutocompletionResult.FromSuccess(results.Take(25).Select(s => new AutocompleteResult(s, s))));
+        return AutocompletionResult.FromSuccess(results.Select(s => new AutocompleteResult(s, s)));
     }
 }

--- a/src/dotBento.Bot/AutoCompleteHandlers/SearchTagsWhenModifyAutoComplete.cs
+++ b/src/dotBento.Bot/AutoCompleteHandlers/SearchTagsWhenModifyAutoComplete.cs
@@ -11,26 +11,14 @@ public sealed class SearchTagsWhenModifyAutoComplete(TagCommands tagCommands) : 
     public override async Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context,
         IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
     {
-        var results = new List<string>();
-        var userId = context.Guild.GetUserAsync(context.User.Id).Result.GuildPermissions.ManageMessages ? (long) context.User.Id : Maybe<long>.None;
-        var tags = await tagCommands.FindTagsAsync((long)context.Guild.Id, true, userId);
-        if (tags.IsFailure)
-        {
-            return await Task.FromResult(AutocompletionResult.FromSuccess(results.Select(s => new AutocompleteResult(s, s))));
-        }
-        
-        if (autocompleteInteraction.Data?.Current?.Value == null ||
-            string.IsNullOrWhiteSpace(autocompleteInteraction.Data?.Current?.Value.ToString()))
-        {
-            results.ReplaceOrAddToList(tags.Value.Select(s => s.Command));
-        }
-        else
-        {
-            var searchValue = autocompleteInteraction.Data.Current.Value.ToString();
-            results.ReplaceOrAddToList(tags.Value.Where(x => x.Command.StartsWith(searchValue ?? "")).Select(s => s.Command));
-        }
+        var guildUser = await context.Guild.GetUserAsync(context.User.Id);
+        var userId = guildUser.GuildPermissions.ManageMessages ? (long)context.User.Id : Maybe<long>.None;
+        var searchValue = autocompleteInteraction.Data?.Current?.Value?.ToString();
+        var results = await tagCommands.FindTagNamesForAutocompleteAsync(
+            (long)context.Guild.Id,
+            userId,
+            searchValue);
 
-        return await Task.FromResult(
-            AutocompletionResult.FromSuccess(results.Take(25).Select(s => new AutocompleteResult(s, s))));
+        return AutocompletionResult.FromSuccess(results.Select(s => new AutocompleteResult(s, s)));
     }
 }

--- a/src/dotBento.Bot/Handlers/ClientLogHandler.cs
+++ b/src/dotBento.Bot/Handlers/ClientLogHandler.cs
@@ -4,7 +4,7 @@ using Serilog;
 
 namespace dotBento.Bot.Handlers;
 
-public sealed class ClientLogHandler
+public sealed class ClientLogHandler : IDisposable
 {
     private readonly DiscordSocketClient _client;
 
@@ -16,33 +16,35 @@ public sealed class ClientLogHandler
 
     private static Task LogEvent(LogMessage logMessage)
     {
-        Task.Run(() =>
+        switch (logMessage.Severity)
         {
-            switch (logMessage.Severity)
-            {
-                case LogSeverity.Critical:
-                    Log.Fatal(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                case LogSeverity.Error:
-                    Log.Error(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                case LogSeverity.Warning:
-                    Log.Warning(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                case LogSeverity.Info:
-                    Log.Information(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                case LogSeverity.Verbose:
-                    Log.Verbose(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                case LogSeverity.Debug:
-                    Log.Debug(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            case LogSeverity.Critical:
+                Log.Fatal(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            case LogSeverity.Error:
+                Log.Error(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            case LogSeverity.Warning:
+                Log.Warning(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            case LogSeverity.Info:
+                Log.Information(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            case LogSeverity.Verbose:
+                Log.Verbose(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            case LogSeverity.Debug:
+                Log.Debug(logMessage.Exception, "{LogMessageSource} | {LogMessage}", logMessage.Source, logMessage.Message);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException();
+        }
 
-        });
         return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _client.Log -= LogEvent;
     }
 }

--- a/src/dotBento.Bot/Services/BackgroundService.cs
+++ b/src/dotBento.Bot/Services/BackgroundService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
 using dotBento.Bot.Models;
@@ -25,6 +24,16 @@ public sealed class BackgroundService(UserService userService,
     IDmSender dmSender,
     IOptions<BotEnvConfig> botSettings)
 {
+    private static readonly string[] RetiredDataMaintenanceJobIds =
+    [
+        "CleanupStaleUsers",
+        "CleanupStaleGuilds",
+        "CleanupStaleGuildMembers",
+        "SyncUserData",
+        "SyncGuildData",
+        "SyncGuildMemberData"
+    ];
+
     public void QueueJobs()
     {
         var environment = botSettings.Value.Environment;
@@ -51,23 +60,7 @@ public sealed class BackgroundService(UserService userService,
             Log.Information($"RecurringJob: Adding {nameof(UpdateMetrics)}");
             RecurringJob.AddOrUpdate(nameof(UpdateMetrics), () => UpdateMetrics(), "* * * * *");
 
-            Log.Information($"RecurringJob: Adding {nameof(CleanupStaleUsers)}");
-            RecurringJob.AddOrUpdate(nameof(CleanupStaleUsers), () => CleanupStaleUsers(), "0 2 * * *");
-
-            Log.Information($"RecurringJob: Adding {nameof(CleanupStaleGuilds)}");
-            RecurringJob.AddOrUpdate(nameof(CleanupStaleGuilds), () => CleanupStaleGuilds(), "0 3 * * *");
-
-            Log.Information($"RecurringJob: Adding {nameof(CleanupStaleGuildMembers)}");
-            RecurringJob.AddOrUpdate(nameof(CleanupStaleGuildMembers), () => CleanupStaleGuildMembers(), "0 4 * * *");
-
-            Log.Information($"RecurringJob: Adding {nameof(SyncUserData)}");
-            RecurringJob.AddOrUpdate(nameof(SyncUserData), () => SyncUserData(), "0 5 * * *");
-
-            Log.Information($"RecurringJob: Adding {nameof(SyncGuildData)}");
-            RecurringJob.AddOrUpdate(nameof(SyncGuildData), () => SyncGuildData(), "0 6 * * *");
-
-            Log.Information($"RecurringJob: Adding {nameof(SyncGuildMemberData)}");
-            RecurringJob.AddOrUpdate(nameof(SyncGuildMemberData), () => SyncGuildMemberData(), "0 7 * * *");
+            RemoveRetiredDataMaintenanceJobs();
 
             // Bot list updates only in production
             if (isProduction)
@@ -84,12 +77,15 @@ public sealed class BackgroundService(UserService userService,
         {
             RecurringJob.RemoveIfExists(nameof(UpdateMetrics));
             RecurringJob.RemoveIfExists(nameof(UpdateBotLists));
-            RecurringJob.RemoveIfExists(nameof(CleanupStaleUsers));
-            RecurringJob.RemoveIfExists(nameof(CleanupStaleGuilds));
-            RecurringJob.RemoveIfExists(nameof(CleanupStaleGuildMembers));
-            RecurringJob.RemoveIfExists(nameof(SyncUserData));
-            RecurringJob.RemoveIfExists(nameof(SyncGuildData));
-            RecurringJob.RemoveIfExists(nameof(SyncGuildMemberData));
+            RemoveRetiredDataMaintenanceJobs();
+        }
+    }
+
+    private static void RemoveRetiredDataMaintenanceJobs()
+    {
+        foreach (var jobId in RetiredDataMaintenanceJobIds)
+        {
+            RecurringJob.RemoveIfExists(jobId);
         }
     }
 
@@ -292,404 +288,5 @@ public sealed class BackgroundService(UserService userService,
     public async Task UpdateBotLists()
     {
         await botListService.UpdateBotLists(client.Guilds.Count);
-    }
-
-    /// <summary>
-    /// Removes guilds from database that the bot is no longer a member of.
-    /// Cascade deletes all guild members for those guilds automatically.
-    /// Runs at 3am daily, after CleanupStaleUsers.
-    /// Processes in batches to avoid memory issues.
-    /// </summary>
-    public async Task CleanupStaleGuilds()
-    {
-        Log.Information($"Running {nameof(CleanupStaleGuilds)}");
-
-        try
-        {
-            if (HasClientNoGuilds(nameof(CleanupStaleGuilds)))
-            {
-                return;
-            }
-
-            const int batchSize = 50;
-            var skip = 0;
-            var totalProcessed = 0;
-            var totalDeleted = 0;
-
-            while (true)
-            {
-                var dbGuilds = await guildService.GetGuildBatchAsync(batchSize, skip);
-                if (dbGuilds.Count == 0) break;
-
-                foreach (var dbGuild in dbGuilds)
-                {
-                    totalProcessed++;
-
-                    // client.GetGuild is a cache lookup, no REST call — no delay needed
-                    var guild = client.GetGuild((ulong)dbGuild.GuildId).AsMaybe();
-                    if (guild.HasNoValue)
-                    {
-                        Log.Information($"Removing stale guild: {dbGuild.GuildName} ({dbGuild.GuildId})");
-                        await guildService.RemoveGuildAsync((ulong)dbGuild.GuildId);
-                        totalDeleted++;
-                    }
-                }
-
-                skip += batchSize;
-            }
-
-            Log.Information($"Completed {nameof(CleanupStaleGuilds)}: Processed {totalProcessed} guilds, deleted {totalDeleted}");
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(CleanupStaleGuilds));
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Removes guild members from database who are no longer in their respective guilds.
-    /// Only handles members who left guilds that the bot is still in (other cases handled by cascade deletion).
-    /// Uses REST API calls to verify membership (not cache) to avoid false positives.
-    /// Runs at 4am daily, after CleanupStaleUsers and CleanupStaleGuilds.
-    /// Processes in batches to avoid memory issues and rate limits.
-    /// </summary>
-    public async Task CleanupStaleGuildMembers()
-    {
-        Log.Information($"Running {nameof(CleanupStaleGuildMembers)}");
-
-        try
-        {
-            if (HasClientNoGuilds(nameof(CleanupStaleGuildMembers)))
-            {
-                return;
-            }
-
-            const int batchSize = 100;
-            var skip = 0;
-            var totalProcessed = 0;
-            var totalDeleted = 0;
-
-            while (true)
-            {
-                var dbGuildMembers = await guildService.GetGuildMemberBatchAsync(batchSize, skip);
-                if (dbGuildMembers.Count == 0) break;
-
-                var guildMembersToDelete = new List<long>();
-
-                foreach (var dbGuildMember in dbGuildMembers)
-                {
-                    totalProcessed++;
-
-                    // client.GetGuild is a cache lookup, no REST call — no delay needed
-                    var guild = client.GetGuild((ulong)dbGuildMember.GuildId).AsMaybe();
-                    if (guild.HasNoValue)
-                    {
-                        // Guild no longer exists in bot's guild list - safe to delete
-                        guildMembersToDelete.Add(dbGuildMember.GuildMemberId);
-                        continue;
-                    }
-
-                    try
-                    {
-                        // Use GetUserAsync to make a REST API call instead of cache lookup
-                        // This ensures we don't delete valid members who just aren't in cache
-                        // Cast to IGuild to access the async REST method
-                        var guildUser = await ((IGuild)guild.Value).GetUserAsync((ulong)dbGuildMember.UserId);
-                        if (guildUser == null)
-                        {
-                            guildMembersToDelete.Add(dbGuildMember.GuildMemberId);
-                        }
-                    }
-                    catch (Discord.Net.HttpException ex) when (ex.HttpCode == System.Net.HttpStatusCode.NotFound)
-                    {
-                        // User not found in guild - safe to delete
-                        guildMembersToDelete.Add(dbGuildMember.GuildMemberId);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Log but don't delete on other errors - better to be safe
-                        Log.Warning(ex, $"Failed to verify guild member {dbGuildMember.GuildMemberId} in guild {dbGuildMember.GuildId}");
-                    }
-
-                    await Task.Delay(10000);
-                }
-
-                if (guildMembersToDelete.Count > 0)
-                {
-                    await guildService.DeleteGuildMembersBulkAsync(guildMembersToDelete);
-                    totalDeleted += guildMembersToDelete.Count;
-                    Log.Information($"Deleted {guildMembersToDelete.Count} stale guild members in this batch");
-                }
-
-                skip += batchSize;
-
-                await Task.Delay(15000);
-            }
-
-            Log.Information($"Completed {nameof(CleanupStaleGuildMembers)}: Processed {totalProcessed} guild members, deleted {totalDeleted}");
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(CleanupStaleGuildMembers));
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Removes users from database who have no guild memberships.
-    /// Cascade deletes any stale guild member records for these users automatically.
-    /// Runs at 2am daily, before CleanupStaleGuilds and CleanupStaleGuildMembers.
-    /// Running first allows cascade deletions from subsequent jobs to handle most cleanup automatically.
-    /// </summary>
-    public async Task CleanupStaleUsers()
-    {
-        Log.Information($"Running {nameof(CleanupStaleUsers)}");
-
-        try
-        {
-            var usersWithNoGuilds = await userService.GetUsersWithoutGuilds();
-
-            if (usersWithNoGuilds.Count > 0)
-            {
-                Log.Information($"Found {usersWithNoGuilds.Count} users with no guild memberships");
-
-                var deletedCount = 0;
-                foreach (var userId in usersWithNoGuilds)
-                {
-                    try
-                    {
-                        await userService.DeleteUserAsync((ulong)userId);
-                        deletedCount++;
-                    }
-                    catch (DbUpdateConcurrencyException)
-                    {
-                        Log.Warning($"User {userId} was already deleted (likely by cascade from guild member cleanup)");
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, $"Failed to delete user {userId}");
-                    }
-
-                    await Task.Delay(100);
-                }
-
-                Log.Information($"Completed {nameof(CleanupStaleUsers)}: Deleted {deletedCount} users ({usersWithNoGuilds.Count - deletedCount} already deleted)");
-            }
-            else
-            {
-                Log.Information($"Completed {nameof(CleanupStaleUsers)}: No users to delete");
-            }
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(CleanupStaleUsers));
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Syncs user data (username, avatar) from Discord for users who can still be resolved.
-    /// Processes in batches to avoid memory issues and rate limits.
-    /// </summary>
-    public async Task SyncUserData()
-    {
-        Log.Information($"Running {nameof(SyncUserData)}");
-
-        try
-        {
-            if (HasClientNoGuilds(nameof(SyncUserData)))
-            {
-                return;
-            }
-
-            const int batchSize = 50;
-            var skip = 0;
-            var totalProcessed = 0;
-            var totalSynced = 0;
-
-            while (true)
-            {
-                var dbUsers = await userService.GetUserBatchAsync(batchSize, skip);
-                if (dbUsers.Count == 0) break;
-
-                foreach (var dbUser in dbUsers)
-                {
-                    totalProcessed++;
-
-                    try
-                    {
-                        var discordUser = (await userResolver.GetUserAsync((ulong)dbUser.UserId)).AsMaybe();
-                        if (discordUser.HasValue)
-                        {
-                            var synced = await userService.SyncUserFromDiscordAsync(dbUser, discordUser.Value);
-                            if (synced)
-                            {
-                                totalSynced++;
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Warning(ex, $"Failed to sync user {dbUser.UserId}");
-                    }
-
-                    await Task.Delay(10000);
-                }
-
-                skip += batchSize;
-
-                await Task.Delay(15000);
-            }
-
-            Log.Information($"Completed {nameof(SyncUserData)}: Processed {totalProcessed} users, synced {totalSynced}");
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(SyncUserData));
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Syncs guild data (name, icon) from Discord.
-    /// Processes in batches to avoid memory issues.
-    /// </summary>
-    public async Task SyncGuildData()
-    {
-        Log.Information($"Running {nameof(SyncGuildData)}");
-
-        try
-        {
-            if (HasClientNoGuilds(nameof(SyncGuildData)))
-            {
-                return;
-            }
-
-            const int batchSize = 50;
-            var skip = 0;
-            var totalProcessed = 0;
-            var totalSynced = 0;
-
-            while (true)
-            {
-                var dbGuilds = await guildService.GetGuildBatchAsync(batchSize, skip);
-                if (dbGuilds.Count == 0) break;
-
-                foreach (var dbGuild in dbGuilds)
-                {
-                    totalProcessed++;
-
-                    try
-                    {
-                        // client.GetGuild is a cache lookup, no REST call — no delay needed
-                        var discordGuild = client.GetGuild((ulong)dbGuild.GuildId).AsMaybe();
-                        if (discordGuild.HasValue)
-                        {
-                            var synced = await guildService.SyncGuildFromDiscordAsync(dbGuild, discordGuild.Value);
-                            if (synced)
-                            {
-                                totalSynced++;
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Warning(ex, $"Failed to sync guild {dbGuild.GuildId}");
-                    }
-                }
-
-                skip += batchSize;
-            }
-
-            Log.Information($"Completed {nameof(SyncGuildData)}: Processed {totalProcessed} guilds, synced {totalSynced}");
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(SyncGuildData));
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Syncs guild member data (avatar) from Discord.
-    /// Uses REST API calls to fetch members (not cache) to ensure all members can be synced.
-    /// Processes in batches to avoid memory issues and rate limits.
-    /// </summary>
-    public async Task SyncGuildMemberData()
-    {
-        Log.Information($"Running {nameof(SyncGuildMemberData)}");
-
-        try
-        {
-            if (HasClientNoGuilds(nameof(SyncGuildMemberData)))
-            {
-                return;
-            }
-
-            const int batchSize = 100;
-            var skip = 0;
-            var totalProcessed = 0;
-            var totalSynced = 0;
-
-            while (true)
-            {
-                var dbGuildMembers = await guildService.GetGuildMemberBatchAsync(batchSize, skip);
-                if (dbGuildMembers.Count == 0) break;
-
-                foreach (var dbGuildMember in dbGuildMembers)
-                {
-                    totalProcessed++;
-
-                    try
-                    {
-                        var discordGuild = client.GetGuild((ulong)dbGuildMember.GuildId).AsMaybe();
-                        if (discordGuild.HasValue)
-                        {
-                            // Use GetUserAsync to make a REST API call instead of cache lookup
-                            // Cast to IGuild to access the async REST method
-                            var discordGuildUser = await ((IGuild)discordGuild.Value).GetUserAsync((ulong)dbGuildMember.UserId);
-                            if (discordGuildUser != null)
-                            {
-                                var synced = await guildService.SyncGuildMemberFromDiscordAsync(dbGuildMember, discordGuildUser);
-                                if (synced)
-                                {
-                                    totalSynced++;
-                                }
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Warning(ex, $"Failed to sync guild member {dbGuildMember.GuildMemberId}");
-                    }
-
-                    await Task.Delay(10000);
-                }
-
-                skip += batchSize;
-
-                await Task.Delay(15000);
-            }
-
-            Log.Information($"Completed {nameof(SyncGuildMemberData)}: Processed {totalProcessed} guild members, synced {totalSynced}");
-        }
-        catch (Exception e)
-        {
-            Log.Error(e, nameof(SyncGuildMemberData));
-            throw;
-        }
-    }
-
-    private bool HasClientNoGuilds(string jobName)
-    {
-        var clientGuilds = client.Guilds.AsMaybe();
-        if (clientGuilds.HasNoValue)
-        {
-            Log.Information($"Client guilds not available, cancelling {jobName}");
-            return true;
-        }
-        
-        return false;
     }
 }

--- a/src/dotBento.Bot/Services/BotListService.cs
+++ b/src/dotBento.Bot/Services/BotListService.cs
@@ -42,9 +42,9 @@ public class BotListService(HttpClient httpClient, IOptions<BotEnvConfig> option
         };
 
         var json = JsonSerializer.Serialize(postData);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var response = await httpClient.PostAsync(requestUri, content);
+        using var response = await httpClient.PostAsync(requestUri, content);
         Log.Information(response.IsSuccessStatusCode
             ? $"{nameof(UpdateBotLists)}: Updated successfully"
             : $"{nameof(UpdateBotLists)}: Failed to post data. Status code: {response.StatusCode}");

--- a/src/dotBento.Infrastructure/Commands/TagCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/TagCommands.cs
@@ -95,6 +95,9 @@ public sealed class TagCommands(TagService tagService)
             ? Result.Success(tags.Value.Select(x => x.ToBentoTag()).ToList())
             : Result.Failure<List<BentoTags>>("No tags found.");
     }
+
+    public async Task<List<string>> FindTagNamesForAutocompleteAsync(long guildId, Maybe<long> authorId, string? query) =>
+        await tagService.FindTagNamesForAutocompleteAsync(guildId, authorId, query);
     
     public async Task<Result<BentoTags>> GetRandomTagAsync(long userId, long guildId)
     {

--- a/src/dotBento.Infrastructure/Services/LeaderboardService.cs
+++ b/src/dotBento.Infrastructure/Services/LeaderboardService.cs
@@ -99,17 +99,11 @@ public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFa
         long guildId, RpsLeaderboardType type, RpsLeaderboardOrder order, int limit = 50)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
-        var guildUserIds = await context.GuildMembers
-            .Where(gm => gm.GuildId == guildId)
-            .Select(gm => gm.UserId)
-            .ToListAsync();
-
         var query = context.RpsGames
-            .Include(r => r.User)
-            .Where(r => guildUserIds.Contains(r.UserId));
+            .AsNoTracking()
+            .Where(r => context.GuildMembers.Any(gm => gm.GuildId == guildId && gm.UserId == r.UserId));
 
-        var games = await query.ToListAsync();
-        var entries = RankRpsGames(games, type, order, limit);
+        var entries = await RankRpsGamesAsync(query, type, order, limit);
 
         return Result.Success(entries);
     }
@@ -118,11 +112,7 @@ public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFa
         RpsLeaderboardType type, RpsLeaderboardOrder order, int limit = 50)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
-        var games = await context.RpsGames
-            .Include(r => r.User)
-            .ToListAsync();
-
-        var entries = RankRpsGames(games, type, order, limit);
+        var entries = await RankRpsGamesAsync(context.RpsGames.AsNoTracking(), type, order, limit);
 
         return Result.Success(entries);
     }
@@ -195,36 +185,40 @@ public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFa
             serverBentoRank));
     }
 
-    private static List<RpsLeaderboardEntry> RankRpsGames(
-        List<EntityFramework.Entities.RpsGame> games,
+    private static async Task<List<RpsLeaderboardEntry>> RankRpsGamesAsync(
+        IQueryable<EntityFramework.Entities.RpsGame> games,
         RpsLeaderboardType type,
         RpsLeaderboardOrder order,
         int limit)
     {
         var projected = games.Select(g =>
-        {
-            var (wins, ties, losses) = type switch
+            new
             {
-                RpsLeaderboardType.Rock => (
-                    g.RockWins ?? 0,
-                    g.RockTies ?? 0,
-                    g.RockLosses ?? 0),
-                RpsLeaderboardType.Paper => (
-                    g.PaperWins ?? 0,
-                    g.PaperTies ?? 0,
-                    g.PaperLosses ?? 0),
-                RpsLeaderboardType.Scissors => (
-                    g.ScissorWins ?? 0,
-                    g.ScissorsTies ?? 0,
-                    g.ScissorsLosses ?? 0),
-                _ => (
-                    (g.RockWins ?? 0) + (g.PaperWins ?? 0) + (g.ScissorWins ?? 0),
-                    (g.RockTies ?? 0) + (g.PaperTies ?? 0) + (g.ScissorsTies ?? 0),
-                    (g.RockLosses ?? 0) + (g.PaperLosses ?? 0) + (g.ScissorsLosses ?? 0))
-            };
-
-            return new { g.UserId, Wins = wins, Ties = ties, Losses = losses, Username = g.User?.Username, Discriminator = g.User?.Discriminator };
-        });
+                g.UserId,
+                Wins = type == RpsLeaderboardType.Rock
+                    ? g.RockWins ?? 0
+                    : type == RpsLeaderboardType.Paper
+                        ? g.PaperWins ?? 0
+                        : type == RpsLeaderboardType.Scissors
+                            ? g.ScissorWins ?? 0
+                            : (g.RockWins ?? 0) + (g.PaperWins ?? 0) + (g.ScissorWins ?? 0),
+                Ties = type == RpsLeaderboardType.Rock
+                    ? g.RockTies ?? 0
+                    : type == RpsLeaderboardType.Paper
+                        ? g.PaperTies ?? 0
+                        : type == RpsLeaderboardType.Scissors
+                            ? g.ScissorsTies ?? 0
+                            : (g.RockTies ?? 0) + (g.PaperTies ?? 0) + (g.ScissorsTies ?? 0),
+                Losses = type == RpsLeaderboardType.Rock
+                    ? g.RockLosses ?? 0
+                    : type == RpsLeaderboardType.Paper
+                        ? g.PaperLosses ?? 0
+                        : type == RpsLeaderboardType.Scissors
+                            ? g.ScissorsLosses ?? 0
+                            : (g.RockLosses ?? 0) + (g.PaperLosses ?? 0) + (g.ScissorsLosses ?? 0),
+                g.User.Username,
+                g.User.Discriminator
+            });
 
         var ordered = order switch
         {
@@ -234,8 +228,11 @@ public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFa
             _ => projected.OrderByDescending(x => x.Wins)
         };
 
-        return ordered
+        var ranked = await ordered
             .Take(limit)
+            .ToListAsync();
+
+        return ranked
             .Select((x, i) => new RpsLeaderboardEntry(
                 i + 1,
                 x.UserId,

--- a/src/dotBento.Infrastructure/Services/TagService.cs
+++ b/src/dotBento.Infrastructure/Services/TagService.cs
@@ -10,12 +10,13 @@ public sealed class TagService(
     IMemoryCache cache,
     IDbContextFactory<BotDbContext> contextFactory)
 {
+    private const int AutocompleteLimit = 25;
+
     private readonly MemoryCacheEntryOptions _cacheOptions = new()
     {
         AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10),
         SlidingExpiration = TimeSpan.FromMinutes(2)
     };
-    private readonly Dictionary<long, List<string>> _cacheKeysByGuild = new();
 
     public async Task<Tag> CreateTagAsync(long userId, long guildId, string name, string content)
     {
@@ -34,7 +35,6 @@ public sealed class TagService(
 
         // TODO: should we invalidate instead of adding to cache?
         InvalidateTagCache(guildId, name);
-        InvalidateTagsCache(guildId);
 
         return tag;
     }
@@ -52,7 +52,6 @@ public sealed class TagService(
         await context.SaveChangesAsync();
 
         InvalidateTagCache(guildId, name);
-        InvalidateTagsCache(guildId);
     }
 
     public async Task UpdateTagAsync(long userId, long guildId, string name, string content)
@@ -68,7 +67,6 @@ public sealed class TagService(
         await context.SaveChangesAsync();
 
         InvalidateTagCache(guildId, name);
-        InvalidateTagsCache(guildId);
     }
 
     public async Task<Maybe<Tag>> FindTagAsync(long guildId, string name)
@@ -76,54 +74,51 @@ public sealed class TagService(
         var cacheKey = GetTagCacheKey(guildId, name);
         if (cache.TryGetValue(cacheKey, out Maybe<Tag> tag)) return tag;
         await using var context = await contextFactory.CreateDbContextAsync();
-        tag = (await context.Tags.FirstOrDefaultAsync(x => x.GuildId == guildId && x.Command == name))?.AsMaybe() ?? Maybe<Tag>.None;
+        tag = (await context.Tags
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.GuildId == guildId && x.Command == name))?.AsMaybe() ?? Maybe<Tag>.None;
             
         cache.Set(cacheKey, tag, _cacheOptions);
-        AddCacheKey(guildId, cacheKey);
         return tag;
     }
 
     public async Task<Result<List<Tag>>> FindTagsAsync(long guildId, bool top, Maybe<long> authorId)
     {
-        var cacheKey = GetTagsCacheKey(guildId);
-        if (cache.TryGetValue(cacheKey, out Result<List<Tag>> tags))
-            return top
-                ? tags.Value.OrderByDescending(x => x.Count).ToList()
-                : tags.Value;
+        await using var context = await contextFactory.CreateDbContextAsync();
+        var query = context.Tags
+            .AsNoTracking()
+            .Where(x => x.GuildId == guildId);
+
+        if (authorId.HasValue)
         {
-            await using var context = await contextFactory.CreateDbContextAsync();
-            var query = context.Tags.Where(x => x.GuildId == guildId);
-            if (authorId.HasValue)
-            {
-                query = query.Where(x => x.UserId == authorId.Value);
-            }
-            tags = await query.ToListAsync();
-            cache.Set(cacheKey, tags, _cacheOptions);
-            AddCacheKey(guildId, cacheKey);
+            query = query.Where(x => x.UserId == authorId.Value);
         }
 
-        return top
-            ? tags.Value.OrderByDescending(x => x.Count).ToList()
-            : tags.Value;
+        query = top
+            ? query.OrderByDescending(x => x.Count)
+            : query.OrderBy(x => x.Command);
+
+        var tags = await query.ToListAsync();
+        return Result.Success(tags);
     }
 
     public async Task<Maybe<Tag>> GetRandomTagAsync(long userId, long guildId)
     {
-        var cacheKey = GetTagsCacheKey(guildId);
-        if (cache.TryGetValue(cacheKey, out Result<List<Tag>> tags))
-        {
-            var random = new Random();
-            var tag = tags.Value[random.Next(tags.Value.Count)];
-            return tag.AsMaybe();
-        }
         await using var context = await contextFactory.CreateDbContextAsync();
-        var query = context.Tags.Where(x => x.GuildId == guildId);
-        tags = await query.ToListAsync();
-        cache.Set(cacheKey, tags, _cacheOptions);
-        AddCacheKey(guildId, cacheKey);
-        return tags.Value.Count != 0
-            ? tags.Value[new Random().Next(tags.Value.Count)].AsMaybe()
-            : Maybe<Tag>.None;
+        var query = context.Tags
+            .AsNoTracking()
+            .Where(x => x.GuildId == guildId);
+        var count = await query.CountAsync();
+        if (count == 0)
+        {
+            return Maybe<Tag>.None;
+        }
+
+        var tag = await query
+            .OrderBy(x => x.TagId)
+            .Skip(Random.Shared.Next(count))
+            .FirstOrDefaultAsync();
+        return tag.AsMaybe();
     }
 
     public async Task RenameTagAsync(long userId, long guildId, string oldName, string newName)
@@ -139,8 +134,7 @@ public sealed class TagService(
         await context.SaveChangesAsync();
 
         InvalidateTagCache(guildId, oldName);
-        //InvalidateTagCache(guildId, newName);
-        InvalidateTagsCache(guildId);
+        InvalidateTagCache(guildId, newName);
     }
 
     public async Task IncrementTagCountAsync(long tagId)
@@ -154,24 +148,49 @@ public sealed class TagService(
         tag.Count++;
         await context.SaveChangesAsync();
 
-        InvalidateTagsCache(tag.GuildId);
+        InvalidateTagCache(tag.GuildId, tag.Command);
     }
 
-    // TODO: use cache for search
     public async Task<List<Tag>> SearchTagsByCommandAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
         return await context.Tags
+            .AsNoTracking()
             .Where(x => x.GuildId == guildId && EF.Functions.ILike(x.Command, $"%{query}%"))
             .ToListAsync();
     }
 
-    // TODO: use cache for search
     public async Task<List<Tag>> SearchTagsByContentAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
         return await context.Tags
+            .AsNoTracking()
             .Where(x => x.GuildId == guildId && EF.Functions.ILike(x.Content, $"%{query}%"))
+            .ToListAsync();
+    }
+
+    public async Task<List<string>> FindTagNamesForAutocompleteAsync(long guildId, Maybe<long> authorId, string? query)
+    {
+        await using var context = await contextFactory.CreateDbContextAsync();
+        var tags = context.Tags
+            .AsNoTracking()
+            .Where(x => x.GuildId == guildId);
+
+        if (authorId.HasValue)
+        {
+            tags = tags.Where(x => x.UserId == authorId.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(query))
+        {
+            tags = tags.Where(x => x.Command.StartsWith(query));
+        }
+
+        return await tags
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Command)
+            .Select(x => x.Command)
+            .Take(AutocompleteLimit)
             .ToListAsync();
     }
 
@@ -179,41 +198,7 @@ public sealed class TagService(
     {
         var cacheKey = GetTagCacheKey(guildId, name);
         cache.Remove(cacheKey);
-        RemoveCacheKey(guildId, cacheKey);
-    }
-
-    private void InvalidateTagsCache(long guildId)
-    {
-        if (!_cacheKeysByGuild.TryGetValue(guildId, out var cacheKeys)) return;
-        foreach (var cacheKey in cacheKeys)
-        {
-            cache.Remove(cacheKey);
-        }
-        _cacheKeysByGuild.Remove(guildId);
     }
 
     private string GetTagCacheKey(long guildId, string name) => $"Tag_{guildId}_{name}";
-    
-    private string GetTagsCacheKey(long guildId) => $"Tags_{guildId}";
-    
-    private void AddCacheKey(long guildId, string cacheKey)
-    {
-        if (!_cacheKeysByGuild.TryGetValue(guildId, out var value))
-        {
-            value = ([]);
-            _cacheKeysByGuild[guildId] = value;
-        }
-
-        value.Add(cacheKey);
-    }
-
-    private void RemoveCacheKey(long guildId, string cacheKey)
-    {
-        if (!_cacheKeysByGuild.TryGetValue(guildId, out var cacheKeys)) return;
-        cacheKeys.Remove(cacheKey);
-        if (cacheKeys.Count == 0)
-        {
-            _cacheKeysByGuild.Remove(guildId);
-        }
-    }
 }

--- a/src/dotBento.Infrastructure/Utilities/StylingUtilities.cs
+++ b/src/dotBento.Infrastructure/Utilities/StylingUtilities.cs
@@ -7,11 +7,33 @@ namespace dotBento.Infrastructure.Utilities;
 
 public sealed class StylingUtilities(HttpClient httpClient)
 {
+    internal const long MaxImageBytes = 8 * 1024 * 1024;
+    private const int MaxSampleDimension = 128;
+
     public async Task<Discord.Color> GetDominantColorAsync(string imageUrl)
     {
-        await using var stream = await httpClient.GetStreamAsync(imageUrl);
-        using var bitmap = SKBitmap.Decode(stream)
+        using var response = await httpClient.GetAsync(imageUrl, HttpCompletionOption.ResponseHeadersRead);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"Could not fetch image. Status code: {(int)response.StatusCode}.");
+        }
+
+        if (response.Content.Headers.ContentLength > MaxImageBytes)
+        {
+            throw new InvalidOperationException($"Image is too large. Maximum size is {MaxImageBytes} bytes.");
+        }
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync();
+        await using var stream = new MaxLengthStream(responseStream, MaxImageBytes);
+        using var codec = SKCodec.Create(stream)
             ?? throw new InvalidOperationException("Could not decode image stream.");
+        using var bitmap = new SKBitmap(GetSampleInfo(codec.Info));
+        var result = codec.GetPixels(bitmap.Info, bitmap.GetPixels());
+        if (result != SKCodecResult.Success && result != SKCodecResult.IncompleteInput)
+        {
+            throw new InvalidOperationException("Could not decode image stream.");
+        }
+
         return CalculateDominantColor(bitmap).ColorToDiscordColor();
     }
 
@@ -45,5 +67,101 @@ public sealed class StylingUtilities(HttpClient httpClient)
         }
 
         return Color.FromArgb((int)(r / total), (int)(g / total), (int)(b / total));
+    }
+
+    private static SKImageInfo GetSampleInfo(SKImageInfo sourceInfo)
+    {
+        if (sourceInfo.Width <= MaxSampleDimension && sourceInfo.Height <= MaxSampleDimension)
+        {
+            return new SKImageInfo(sourceInfo.Width, sourceInfo.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        }
+
+        var scale = Math.Min(
+            MaxSampleDimension / (double)sourceInfo.Width,
+            MaxSampleDimension / (double)sourceInfo.Height);
+        var width = Math.Max(1, (int)Math.Round(sourceInfo.Width * scale));
+        var height = Math.Max(1, (int)Math.Round(sourceInfo.Height * scale));
+
+        return new SKImageInfo(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+    }
+
+    private sealed class MaxLengthStream(Stream innerStream, long maxBytes) : Stream
+    {
+        private long _totalBytesRead;
+
+        public override bool CanRead => innerStream.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => _totalBytesRead;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush() => innerStream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = innerStream.Read(buffer, offset, count);
+            TrackBytesRead(read);
+            return read;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var read = innerStream.Read(buffer);
+            TrackBytesRead(read);
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+            TrackBytesRead(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await innerStream.ReadAsync(buffer, cancellationToken);
+            TrackBytesRead(read);
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override void Write(ReadOnlySpan<byte> buffer) =>
+            throw new NotSupportedException();
+
+        public override ValueTask DisposeAsync() =>
+            innerStream.DisposeAsync();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void TrackBytesRead(int bytesRead)
+        {
+            _totalBytesRead += bytesRead;
+            if (_totalBytesRead > maxBytes)
+            {
+                throw new InvalidOperationException($"Image is too large. Maximum size is {maxBytes} bytes.");
+            }
+        }
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/LeaderboardServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/LeaderboardServiceTests.cs
@@ -301,6 +301,50 @@ public class LeaderboardServiceTests
         Assert.Equal("RpsUser3", result.Value[0].Username);
     }
 
+    [Fact]
+    public async Task GetGlobalRpsLeaderboardAsync_RespectsLimit()
+    {
+        var factory = new InMemoryDbFactory();
+        await SeedRpsGamesAsync(factory, 10);
+        var service = new LeaderboardService(factory);
+
+        var result = await service.GetGlobalRpsLeaderboardAsync(
+            RpsLeaderboardType.All,
+            RpsLeaderboardOrder.Wins,
+            3);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.Value.Count);
+        Assert.Equal([1, 2, 3], result.Value.Select(x => x.Rank));
+    }
+
+    [Fact]
+    public async Task GetServerRpsLeaderboardAsync_ReturnsOnlyGuildMembers()
+    {
+        var factory = new InMemoryDbFactory();
+        const long guildId = 30;
+        await SeedRpsGamesAsync(factory, 5);
+
+        await using (var db = await factory.CreateDbContextAsync())
+        {
+            db.Guilds.Add(new Guild { GuildId = guildId, GuildName = "RpsGuild", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            db.GuildMembers.Add(new GuildMember { GuildId = guildId, UserId = 301, Level = 1, Xp = 0 });
+            db.GuildMembers.Add(new GuildMember { GuildId = guildId, UserId = 303, Level = 1, Xp = 0 });
+            await db.SaveChangesAsync();
+        }
+
+        var service = new LeaderboardService(factory);
+
+        var result = await service.GetServerRpsLeaderboardAsync(
+            guildId,
+            RpsLeaderboardType.All,
+            RpsLeaderboardOrder.Wins);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value.Count);
+        Assert.Equal([301, 303], result.Value.Select(x => x.UserId));
+    }
+
     // --- User Summary ---
 
     [Fact]

--- a/tests/dotBento.Infrastructure.Tests/Services/TagServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/TagServiceTests.cs
@@ -1,0 +1,81 @@
+using CSharpFunctionalExtensions;
+using dotBento.EntityFramework.Context;
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public sealed class TagServiceTests
+{
+    private sealed class InMemoryDbFactory : IDbContextFactory<BotDbContext>
+    {
+        private readonly string _dbName = Guid.NewGuid().ToString();
+        private readonly InMemoryDatabaseRoot _root = new();
+        private readonly IConfiguration _config = new ConfigurationBuilder().Build();
+
+        public BotDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<BotDbContext>()
+                .UseInMemoryDatabase(_dbName, _root)
+                .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+                .Options;
+            return new BotDbContext(_config, options);
+        }
+
+        public Task<BotDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    [Fact]
+    public async Task FindTagNamesForAutocompleteAsync_ReturnsAtMostTwentyFiveNames()
+    {
+        var factory = new InMemoryDbFactory();
+        await SeedTagsAsync(factory, 1, 30);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new TagService(cache, factory);
+
+        var result = await service.FindTagNamesForAutocompleteAsync(1, Maybe<long>.None, null);
+
+        Assert.Equal(25, result.Count);
+        Assert.Equal("tag-30-author-200", result[0]);
+    }
+
+    [Fact]
+    public async Task FindTagNamesForAutocompleteAsync_FiltersByAuthorAndPrefix()
+    {
+        var factory = new InMemoryDbFactory();
+        await SeedTagsAsync(factory, 1, 10);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new TagService(cache, factory);
+
+        var result = await service.FindTagNamesForAutocompleteAsync(1, 200, "tag-");
+
+        Assert.NotEmpty(result);
+        Assert.All(result, name => Assert.Contains("-author-200", name));
+    }
+
+    private static async Task SeedTagsAsync(IDbContextFactory<BotDbContext> factory, long guildId, int count)
+    {
+        await using var db = await factory.CreateDbContextAsync();
+        for (var i = 1; i <= count; i++)
+        {
+            var authorId = i % 2 == 0 ? 200 : 100;
+            db.Tags.Add(new Tag
+            {
+                GuildId = guildId,
+                UserId = authorId,
+                Command = $"tag-{i:00}-author-{authorId}",
+                Content = new string('x', 2000),
+                Count = i,
+                Date = DateTime.UtcNow
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
@@ -71,6 +71,64 @@ public class StylingUtilitiesTests
     }
 
     [Fact]
+    public async Task TryGetDominantColorAsync_ReturnsFailure_WhenContentLengthExceedsLimit()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new ByteArrayContent([])
+        };
+        response.Content.Headers.ContentLength = StylingUtilities.MaxImageBytes + 1;
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(response);
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var utilities = new StylingUtilities(httpClient);
+
+        var result = await utilities.TryGetDominantColorAsync("http://fake-image-url");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Image is too large", result.Error);
+    }
+
+    [Fact]
+    public async Task TryGetDominantColorAsync_ReturnsFailure_WhenStreamExceedsLimitWithoutContentLength()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        var stream = new OversizedImageStream(StylingUtilities.MaxImageBytes + 1);
+
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StreamContent(stream)
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var utilities = new StylingUtilities(httpClient);
+
+        var result = await utilities.TryGetDominantColorAsync("http://fake-image-url");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Image is too large", result.Error);
+    }
+
+    [Fact]
     public void CalculateDominantColor_ReturnsAverageColor()
     {
         // Arrange
@@ -85,5 +143,47 @@ public class StylingUtilitiesTests
 
         // Assert
         Assert.Equal(System.Drawing.Color.FromArgb(150, 125, 125), result);
+    }
+
+    private sealed class OversizedImageStream(long length) : Stream
+    {
+        private long _position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => length;
+
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_position >= length)
+            {
+                return 0;
+            }
+
+            var read = (int)Math.Min(count, length - _position);
+            Array.Fill(buffer, (byte)0x89, offset, read);
+            _position += read;
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- remove high-risk background data maintenance jobs while preserving member count and leaderboard avatar updates
- reduce memory pressure from RPS leaderboards, tag autocomplete/list caching, dominant-color image decoding, bot-list HTTP posts, and Discord log handling
- keep `AlwaysDownloadUsers` unchanged because current command paths still assume guild member cache availability

## Verification
- `dotnet build dotBento.sln --no-restore -m:1`
- `dotnet test tests/dotBento.Infrastructure.Tests/dotBento.Infrastructure.Tests.csproj --no-restore -m:1` exits 0 but reports no discovered tests
- `dotnet test tests/dotBento.Bot.Tests/dotBento.Bot.Tests.csproj --no-restore -m:1` exits 0 but reports no discovered tests