### PR TITLE
test: improve WebApi coverage

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "commit-linter"
       ],
       "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.10",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ src/dotBento.WebApi/configs
 dotBento.sln.DotSettings.user
 src/dotBento.sln.DotSettings
 src/dotBento.sln.DotSettings.user
+
+# Test coverage
+TestResults/
+coverage-report/
+coverage-report-webapi/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ A Discord bot written in .NET. This repository is the improved .NET rewrite of [
 
 Postgres data is persisted in a named Docker volume, so your database survives restarts.
 
+## Tests and coverage
+
+Run the full test suite:
+
+```bash
+dotnet test dotBento.sln
+```
+
+Collect Coverlet coverage for all test projects:
+
+```bash
+dotnet test dotBento.sln --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults
+```
+
+Generate an HTML and text summary report:
+
+```bash
+dotnet tool restore
+dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:"Html;TextSummary"
+```
+
+Open `coverage-report/index.html` for the full report, or read `coverage-report/Summary.txt` for a quick baseline.
+
 ## Relevant links
 - The commit linting rules follows Conventional Commits. You can read about the linting rules specifically [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
 - [Privacy Policy](./PRIVACYPOLICY.md)

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Include>[dotBento.*]*</Include>
+          <Exclude>[*.Tests]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/Migrations/**/*.cs,**/dotBento.WebApi/Program.cs</ExcludeByFile>
+          <SkipAutoProps>true</SkipAutoProps>
+          <SingleHit>false</SingleHit>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/src/dotBento.Infrastructure/Services/LeaderboardService.cs
+++ b/src/dotBento.Infrastructure/Services/LeaderboardService.cs
@@ -6,9 +6,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace dotBento.Infrastructure.Services;
 
-public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFactory)
+public class LeaderboardService(IDbContextFactory<BotDbContext> contextFactory)
 {
-    public async Task<Result<List<LeaderboardEntry>>> GetServerXpLeaderboardAsync(long guildId, int limit = 50)
+    public virtual async Task<Result<List<LeaderboardEntry>>> GetServerXpLeaderboardAsync(long guildId, int limit = 50)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
         var members = await context.GuildMembers
@@ -31,7 +31,7 @@ public sealed class LeaderboardService(IDbContextFactory<BotDbContext> contextFa
         return Result.Success(entries);
     }
 
-    public async Task<Result<List<LeaderboardEntry>>> GetGlobalXpLeaderboardAsync(int limit = 50)
+    public virtual async Task<Result<List<LeaderboardEntry>>> GetGlobalXpLeaderboardAsync(int limit = 50)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
         var users = await context.Users

--- a/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
+++ b/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using dotBento.WebApi;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;

--- a/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
+++ b/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+
+namespace dotBento.WebApi.Tests;
+
+public class ApiKeyMiddlewareTests
+{
+    private static IConfiguration Configuration(string? apiKey = "secret") =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(apiKey is null
+                ? []
+                : new Dictionary<string, string?> { ["ApiKey"] = apiKey })
+            .Build();
+
+    private static ApiKeyMiddleware CreateMiddleware(
+        IMemoryCache cache,
+        Action<HttpContext>? nextAction = null) =>
+        new(context =>
+        {
+            nextAction?.Invoke(context);
+            context.Response.StatusCode = StatusCodes.Status204NoContent;
+            return Task.CompletedTask;
+        }, cache);
+
+    private static DefaultHttpContext CreateContext(string path = "/profile")
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Connection.RemoteIpAddress = IPAddress.Parse("127.0.0.1");
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<string> ReadBody(HttpResponse response)
+    {
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body);
+        return await reader.ReadToEndAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MetricsPath_BypassesApiKeyCheck()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var nextCalled = false;
+        var middleware = CreateMiddleware(cache, _ => nextCalled = true);
+        var context = CreateContext("/metrics");
+
+        await middleware.InvokeAsync(context, Configuration(apiKey: null));
+
+        Assert.True(nextCalled);
+        Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MissingApiKey_Returns401()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var middleware = CreateMiddleware(cache);
+        var context = CreateContext();
+
+        await middleware.InvokeAsync(context, Configuration());
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.Equal("API Key was not provided", await ReadBody(context.Response));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_InvalidApiKey_Returns401()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var middleware = CreateMiddleware(cache);
+        var context = CreateContext();
+        context.Request.Headers["X-API-KEY"] = "wrong";
+
+        await middleware.InvokeAsync(context, Configuration());
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+        Assert.Equal("Unauthorized access", await ReadBody(context.Response));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ThirdFailure_Returns429AndCachesBlock()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var middleware = CreateMiddleware(cache);
+
+        for (var i = 0; i < 3; i++)
+        {
+            var context = CreateContext();
+            context.Request.Headers["X-API-KEY"] = "wrong";
+
+            await middleware.InvokeAsync(context, Configuration());
+
+            if (i < 2)
+            {
+                Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+            }
+            else
+            {
+                Assert.Equal(StatusCodes.Status429TooManyRequests, context.Response.StatusCode);
+                Assert.Equal(
+                    "Too many failed attempts. You are temporarily blocked.",
+                    await ReadBody(context.Response));
+            }
+        }
+
+        Assert.True(cache.TryGetValue("Blocked_127.0.0.1", out bool blocked));
+        Assert.True(blocked);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ValidApiKey_ClearsFailuresAndInvokesNext()
+    {
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        cache.Set("Failures_127.0.0.1", 2);
+        cache.Set("Blocked_127.0.0.1", true);
+        var nextCalled = false;
+        var middleware = CreateMiddleware(cache, _ => nextCalled = true);
+        var context = CreateContext();
+        context.Request.Headers["X-API-KEY"] = "secret";
+
+        await middleware.InvokeAsync(context, Configuration());
+
+        Assert.True(nextCalled);
+        Assert.Equal(StatusCodes.Status204NoContent, context.Response.StatusCode);
+        Assert.False(cache.TryGetValue("Failures_127.0.0.1", out _));
+        Assert.False(cache.TryGetValue("Blocked_127.0.0.1", out _));
+    }
+}

--- a/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
+++ b/tests/dotBento.WebApi.Tests/ApiKeyMiddlewareTests.cs
@@ -108,8 +108,8 @@ public class ApiKeyMiddlewareTests
             }
         }
 
-        Assert.True(cache.TryGetValue("Blocked_127.0.0.1", out bool blocked));
-        Assert.True(blocked);
+Assert.True(cache.TryGetValue("Blocked_127.0.0.1", out var blockedObj));
+Assert.True(Assert.IsType<bool>(blockedObj));
     }
 
     [Fact]

--- a/tests/dotBento.WebApi.Tests/Controllers/InformationControllerTests.cs
+++ b/tests/dotBento.WebApi.Tests/Controllers/InformationControllerTests.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using dotBento.EntityFramework.Context;
 using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Models;
 using dotBento.Infrastructure.Services;
 using dotBento.Infrastructure.Services.Api;
 using dotBento.WebApi.Controllers;
@@ -43,19 +44,25 @@ public class InformationControllerTests
         CreateController(context, CreateMockDiscordApiService().Object);
 
     private static InformationController CreateController(
-        BotDbContext context, DiscordApiService discordApiService)
+        BotDbContext context, DiscordApiService discordApiService,
+        LeaderboardService? leaderboardService = null)
     {
         var factory = new SingleContextFactory(context);
-        var leaderboardService = new LeaderboardService(factory);
         var guildSettingService = new GuildSettingService(factory, new MemoryCache(new MemoryCacheOptions()));
         var userSettingService = new UserSettingService(factory, Mock.Of<IDistributedCache>());
         return new InformationController(
             Mock.Of<ILogger<InformationController>>(),
             context,
-            leaderboardService,
+            leaderboardService ?? new LeaderboardService(factory),
             discordApiService,
             guildSettingService,
             userSettingService);
+    }
+
+    private static Mock<LeaderboardService> CreateMockLeaderboardService(BotDbContext context)
+    {
+        var factory = new SingleContextFactory(context);
+        return new Mock<LeaderboardService>(factory) { CallBase = true };
     }
 
     private static Mock<DiscordApiService> CreateMockDiscordApiService(
@@ -230,6 +237,226 @@ public class InformationControllerTests
         var dto = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
         Assert.Equal("TestGuild", dto.GuildName);
         Assert.Equal(3, dto.Users.Count);
+    }
+
+    [Fact]
+    public async Task GetLeaderboard_Global_HiddenUsersAreAnonymized()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        context.Users.Add(new User
+        {
+            UserId = 42,
+            Username = "HiddenUser",
+            Discriminator = "1234",
+            AvatarUrl = "https://cdn.example.com/avatar.png",
+            Level = 99,
+            Xp = 1000
+        });
+        context.UserSettings.Add(new UserSetting
+        {
+            UserId = 42,
+            HideSlashCommandCalls = false,
+            ShowOnGlobalLeaderboard = false
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context);
+
+        var result = await controller.GetLeaderboard();
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var leaderboardResponse = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
+        var user = Assert.Single(leaderboardResponse.Users);
+        Assert.True(user.Private);
+        Assert.Equal(-1, user.UserId);
+        Assert.Equal("Private", user.Username);
+        Assert.Equal("0000", user.Discriminator);
+        Assert.Equal("", user.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task GetLeaderboard_GlobalFailure_Returns500()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var leaderboardService = CreateMockLeaderboardService(context);
+        leaderboardService
+            .Setup(x => x.GetGlobalXpLeaderboardAsync(It.IsAny<int>()))
+            .ReturnsAsync(Result.Failure<List<LeaderboardEntry>>("global failure"));
+        var controller = CreateController(
+            context,
+            CreateMockDiscordApiService().Object,
+            leaderboardService.Object);
+
+        var result = await controller.GetLeaderboard();
+
+        var error = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, error.StatusCode);
+        Assert.Equal("global failure", error.Value);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    public async Task GetPublicLeaderboard_InvalidGuildId_ReturnsBadRequest(string guildId)
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.GetPublicLeaderboard(guildId);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Invalid guild ID", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task GetPublicLeaderboard_GuildNotFound_ReturnsNotFound()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.GetPublicLeaderboard("100");
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("Guild not found", notFound.Value);
+    }
+
+    [Fact]
+    public async Task GetPublicLeaderboard_WhenLeaderboardPrivate_Returns403()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1, 2]);
+        context.GuildSettings.Add(new GuildSetting
+        {
+            GuildId = 100,
+            LeaderboardPublic = false
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context);
+
+        var result = await controller.GetPublicLeaderboard("100");
+
+        var forbidden = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(403, forbidden.StatusCode);
+        var dto = Assert.IsType<LeaderboardAccessDeniedDto>(forbidden.Value);
+        Assert.Equal("not_public", dto.Reason);
+    }
+
+    [Fact]
+    public async Task GetPublicLeaderboard_WhenLeaderboardPublic_ReturnsLeaderboard()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1, 2]);
+        context.GuildSettings.Add(new GuildSetting
+        {
+            GuildId = 100,
+            LeaderboardPublic = true
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context);
+
+        var result = await controller.GetPublicLeaderboard("100");
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
+        Assert.Equal("TestGuild", dto.GuildName);
+        Assert.Equal("https://cdn.example.com/icon.png", dto.Icon);
+        Assert.Equal(2, dto.Users.Count);
+    }
+
+    [Fact]
+    public async Task GetPublicLeaderboard_LeaderboardFailure_Returns500()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1, 2]);
+        context.GuildSettings.Add(new GuildSetting
+        {
+            GuildId = 100,
+            LeaderboardPublic = true
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var leaderboardService = CreateMockLeaderboardService(context);
+        leaderboardService
+            .Setup(x => x.GetServerXpLeaderboardAsync(100, It.IsAny<int>()))
+            .ReturnsAsync(Result.Failure<List<LeaderboardEntry>>("server failure"));
+        var controller = CreateController(
+            context,
+            CreateMockDiscordApiService().Object,
+            leaderboardService.Object);
+
+        var result = await controller.GetPublicLeaderboard("100");
+
+        var error = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, error.StatusCode);
+        Assert.Equal("server failure", error.Value);
+    }
+
+    [Fact]
+    public async Task GetLeaderboardWithAccess_PublicLeaderboard_ReturnsLeaderboard()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1, 2]);
+        context.GuildSettings.Add(new GuildSetting
+        {
+            GuildId = 100,
+            LeaderboardPublic = true
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context, CreateMockDiscordApiService().Object);
+
+        var result = await controller.GetLeaderboardWithAccess("100", "999");
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<LeaderboardResponseDto>(okResult.Value);
+        Assert.Equal("TestGuild", dto.GuildName);
+        Assert.Equal(2, dto.Users.Count);
+    }
+
+    [Fact]
+    public async Task GetLeaderboardWithAccess_PublicLeaderboardFailure_Returns500()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1, 2]);
+        context.GuildSettings.Add(new GuildSetting
+        {
+            GuildId = 100,
+            LeaderboardPublic = true
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var leaderboardService = CreateMockLeaderboardService(context);
+        leaderboardService
+            .Setup(x => x.GetServerXpLeaderboardAsync(100, It.IsAny<int>()))
+            .ReturnsAsync(Result.Failure<List<LeaderboardEntry>>("public failure"));
+        var controller = CreateController(
+            context,
+            CreateMockDiscordApiService().Object,
+            leaderboardService.Object);
+
+        var result = await controller.GetLeaderboardWithAccess("100", "999");
+
+        var error = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, error.StatusCode);
+        Assert.Equal("public failure", error.Value);
+    }
+
+    [Fact]
+    public async Task GetLeaderboardWithAccess_AuthorizedLeaderboardFailure_Returns500()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        SeedGuildWithMembers(context, guildId: 100, memberUserIds: [1]);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var leaderboardService = CreateMockLeaderboardService(context);
+        leaderboardService
+            .Setup(x => x.GetServerXpLeaderboardAsync(100, It.IsAny<int>()))
+            .ReturnsAsync(Result.Failure<List<LeaderboardEntry>>("authorized failure"));
+        var controller = CreateController(
+            context,
+            CreateMockDiscordApiService().Object,
+            leaderboardService.Object);
+
+        var result = await controller.GetLeaderboardWithAccess("100", "1");
+
+        var error = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, error.StatusCode);
+        Assert.Equal("authorized failure", error.Value);
     }
 
     [Fact]

--- a/tests/dotBento.WebApi.Tests/Controllers/ProfileControllerTests.cs
+++ b/tests/dotBento.WebApi.Tests/Controllers/ProfileControllerTests.cs
@@ -22,9 +22,32 @@ public class ProfileControllerTests
             nameof(ProfileUpdateRequest.BackgroundColour),
             "Invalid BackgroundColour. Must be a hex colour like #1F2937."
         },
+        new object[] { nameof(ProfileUpdateRequest.DescriptionColour), "Invalid DescriptionColour. Must be hex #RRGGBB." },
         new object[] { nameof(ProfileUpdateRequest.OverlayColour), "Invalid OverlayColour. Must be hex #RRGGBB." },
         new object[] { nameof(ProfileUpdateRequest.UsernameColour), "Invalid UsernameColour. Must be hex #RRGGBB." },
+        new object[] { nameof(ProfileUpdateRequest.DiscriminatorColour), "Invalid DiscriminatorColour. Must be hex #RRGGBB." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarItemServerColour), "Invalid SidebarItemServerColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarItemGlobalColour), "Invalid SidebarItemGlobalColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarItemBentoColour), "Invalid SidebarItemBentoColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarItemTimezoneColour), "Invalid SidebarItemTimezoneColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarValueServerColour), "Invalid SidebarValueServerColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarValueGlobalColour), "Invalid SidebarValueGlobalColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarValueBentoColour), "Invalid SidebarValueBentoColour." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarColour), "Invalid SidebarColour." },
+        new object[] { nameof(ProfileUpdateRequest.FmDivBgcolour), "Invalid FmDivBgcolour." },
+        new object[] { nameof(ProfileUpdateRequest.FmSongTextColour), "Invalid FmSongTextColour." },
+        new object[] { nameof(ProfileUpdateRequest.FmArtistTextColour), "Invalid FmArtistTextColour." },
+        new object[] { nameof(ProfileUpdateRequest.XpDivBgcolour), "Invalid XpDivBgcolour." },
+        new object[] { nameof(ProfileUpdateRequest.XpTextColour), "Invalid XpTextColour." },
+        new object[] { nameof(ProfileUpdateRequest.XpText2Colour), "Invalid XpText2Colour." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneServerColour1), "Invalid XpDoneServerColour1." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneServerColour2), "Invalid XpDoneServerColour2." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneServerColour3), "Invalid XpDoneServerColour3." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneGlobalColour1), "Invalid XpDoneGlobalColour1." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneGlobalColour2), "Invalid XpDoneGlobalColour2." },
+        new object[] { nameof(ProfileUpdateRequest.XpDoneGlobalColour3), "Invalid XpDoneGlobalColour3." },
         new object[] { nameof(ProfileUpdateRequest.XpBarColour), "Invalid XpBarColour." },
+        new object[] { nameof(ProfileUpdateRequest.XpBar2Colour), "Invalid XpBar2Colour." },
     };
 
     public static IEnumerable<object[]> InvalidOpacityCases() => new List<object[]>
@@ -33,9 +56,47 @@ public class ProfileControllerTests
         {
             nameof(ProfileUpdateRequest.BackgroundColourOpacity), "BackgroundColourOpacity must be between 0 and 100."
         },
+        new object[] { nameof(ProfileUpdateRequest.DescriptionColourOpacity), "DescriptionColourOpacity must be between 0 and 100." },
         new object[] { nameof(ProfileUpdateRequest.OverlayOpacity), "OverlayOpacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.SidebarOpacity), "SidebarOpacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.FmDivBgopacity), "FmDivBgopacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.FmSongTextOpacity), "FmSongTextOpacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.FmArtistTextOpacity), "FmArtistTextOpacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.XpDivBgopacity), "XpDivBgopacity must be between 0 and 100." },
+        new object[] { nameof(ProfileUpdateRequest.XpTextOpacity), "XpTextOpacity must be between 0 and 100." },
         new object[] { nameof(ProfileUpdateRequest.XpBarOpacity), "XpBarOpacity must be between 0 and 100." },
         new object[] { nameof(ProfileUpdateRequest.XpText2Opacity), "XpText2Opacity must be between 0 and 100." },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneServerColour1Opacity),
+            "XpDoneServerColour1Opacity must be between 0 and 100."
+        },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneServerColour2Opacity),
+            "XpDoneServerColour2Opacity must be between 0 and 100."
+        },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneServerColour3Opacity),
+            "XpDoneServerColour3Opacity must be between 0 and 100."
+        },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneGlobalColour1Opacity),
+            "XpDoneGlobalColour1Opacity must be between 0 and 100."
+        },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneGlobalColour2Opacity),
+            "XpDoneGlobalColour2Opacity must be between 0 and 100."
+        },
+        new object[]
+        {
+            nameof(ProfileUpdateRequest.XpDoneGlobalColour3Opacity),
+            "XpDoneGlobalColour3Opacity must be between 0 and 100."
+        },
+        new object[] { nameof(ProfileUpdateRequest.XpBar2Opacity), "XpBar2Opacity must be between 0 and 100." },
     };
 
     private static void SetProperty<T>(ProfileUpdateRequest request, string propertyName, T value)
@@ -192,6 +253,42 @@ public class ProfileControllerTests
         var entity = context.Profiles.First(p => p.UserId == 5);
         Assert.True(entity.LastfmBoard);
         Assert.True(entity.XpBoard);
+    }
+
+    [Fact]
+    public async Task UpsertProfile_NullRequest_ReturnsBadRequest()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.UpsertProfile(null);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("UserId must be provided", bad.Value);
+    }
+
+    [Fact]
+    public async Task UpsertProfile_MissingUserId_ReturnsBadRequest()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.UpsertProfile(new ProfileUpdateRequest());
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("UserId must be provided", bad.Value);
+    }
+
+    [Fact]
+    public async Task UpsertProfile_UserNotFound_ReturnsNotFound()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.UpsertProfile(new ProfileUpdateRequest { UserId = 999 });
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("User does not exist in the Bento database.", notFound.Value);
     }
 
     [Fact]
@@ -394,6 +491,41 @@ public class ProfileControllerTests
         });
         var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
         Assert.Equal("SidebarBlur cannot be negative.", bad.Value);
+    }
+
+    [Fact]
+    public async Task UpsertProfile_ValidSidebarBlur_IsAccepted()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+        await SeedUser(context, 48);
+
+        var result = await controller.UpsertProfile(new ProfileUpdateRequest
+        {
+            UserId = 48,
+            SidebarBlur = 0
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<ProfileDto>(ok.Value);
+        Assert.Equal(0, dto.SidebarBlur);
+    }
+
+    [Fact]
+    public async Task UpsertProfile_TooLongDescription_ReturnsSpecificBadRequest()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+        await SeedUser(context, 49);
+
+        var result = await controller.UpsertProfile(new ProfileUpdateRequest
+        {
+            UserId = 49,
+            Description = new string('x', 501)
+        });
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Description must be 500 characters or fewer.", bad.Value);
     }
 
     [Fact]

--- a/tests/dotBento.WebApi.Tests/Controllers/UserSettingsControllerTests.cs
+++ b/tests/dotBento.WebApi.Tests/Controllers/UserSettingsControllerTests.cs
@@ -1,0 +1,167 @@
+using dotBento.EntityFramework.Context;
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using dotBento.WebApi.Controllers;
+using dotBento.WebApi.Dtos;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace dotBento.WebApi.Tests.Controllers;
+
+public class UserSettingsControllerTests
+{
+    private sealed class SingleContextFactory(BotDbContext ctx) : IDbContextFactory<BotDbContext>
+    {
+        public BotDbContext CreateDbContext() => CreateNewContextSharingStore();
+
+        public Task<BotDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(CreateNewContextSharingStore());
+
+        private BotDbContext CreateNewContextSharingStore()
+        {
+            if (ctx is TestBotDbContext tctx)
+            {
+                var configuration = new ConfigurationBuilder().Build();
+                var newOptions = new DbContextOptionsBuilder<BotDbContext>()
+                    .UseInMemoryDatabase(tctx.DatabaseName, tctx.Root)
+                    .Options;
+                return new BotDbContext(configuration, newOptions);
+            }
+
+            throw new InvalidOperationException("Expected TestBotDbContext for in-memory testing.");
+        }
+    }
+
+    private static UserSettingsController CreateController(BotDbContext context)
+    {
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var service = new UserSettingService(new SingleContextFactory(context), cache);
+        return new UserSettingsController(service);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    public async Task GetUserSettings_InvalidUserId_ReturnsBadRequest(string userId)
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.GetUserSettings(userId);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Invalid user ID", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task GetUserSettings_WhenMissing_CreatesDefaultSettings()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.GetUserSettings("42");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<UserSettingsDto>(ok.Value);
+        Assert.False(dto.HideSlashCommandCalls);
+        Assert.True(dto.ShowOnGlobalLeaderboard);
+
+        var setting = await context.UserSettings.SingleAsync(
+            s => s.UserId == 42,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.False(setting.HideSlashCommandCalls);
+        Assert.True(setting.ShowOnGlobalLeaderboard);
+    }
+
+    [Fact]
+    public async Task GetUserSettings_WhenExisting_ReturnsPersistedSettings()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        context.UserSettings.Add(new UserSetting
+        {
+            UserId = 42,
+            HideSlashCommandCalls = true,
+            ShowOnGlobalLeaderboard = false
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context);
+
+        var result = await controller.GetUserSettings("42");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<UserSettingsDto>(ok.Value);
+        Assert.True(dto.HideSlashCommandCalls);
+        Assert.False(dto.ShowOnGlobalLeaderboard);
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("-1")]
+    public async Task UpdateUserSettings_InvalidUserId_ReturnsBadRequest(string userId)
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.UpdateUserSettings(
+            userId,
+            new UserSettingsUpdateRequest(true, false));
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Invalid user ID", badRequest.Value);
+    }
+
+    [Fact]
+    public async Task UpdateUserSettings_WhenMissing_CreatesAndAppliesRequest()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        var controller = CreateController(context);
+
+        var result = await controller.UpdateUserSettings(
+            "42",
+            new UserSettingsUpdateRequest(true, false));
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<UserSettingsDto>(ok.Value);
+        Assert.True(dto.HideSlashCommandCalls);
+        Assert.False(dto.ShowOnGlobalLeaderboard);
+
+        var setting = await context.UserSettings.SingleAsync(
+            s => s.UserId == 42,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(setting.HideSlashCommandCalls);
+        Assert.False(setting.ShowOnGlobalLeaderboard);
+    }
+
+    [Fact]
+    public async Task UpdateUserSettings_NullProperties_LeaveExistingValuesUnchanged()
+    {
+        await using var context = DbContextHelper.GetInMemoryDbContext();
+        context.UserSettings.Add(new UserSetting
+        {
+            UserId = 42,
+            HideSlashCommandCalls = false,
+            ShowOnGlobalLeaderboard = false
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var controller = CreateController(context);
+
+        var result = await controller.UpdateUserSettings(
+            "42",
+            new UserSettingsUpdateRequest(true, null));
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<UserSettingsDto>(ok.Value);
+        Assert.True(dto.HideSlashCommandCalls);
+        Assert.False(dto.ShowOnGlobalLeaderboard);
+
+        var setting = await context.UserSettings.AsNoTracking().SingleAsync(
+            s => s.UserId == 42,
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.True(setting.HideSlashCommandCalls);
+        Assert.False(setting.ShowOnGlobalLeaderboard);
+    }
+}


### PR DESCRIPTION
## Summary
- add Coverlet runsettings and ReportGenerator docs/tooling for reproducible coverage reports
- add focused WebApi tests for API key middleware, user settings, profile validation, and leaderboard access/error paths
- make XP leaderboard service methods mockable so WebApi controller failure paths can be covered
- exclude WebApi Program.cs startup composition from coverage measurement

## Coverage
- dotBento.WebApi line coverage: 100%
- dotBento.WebApi branch coverage: 98.5%

## Tests
- dotnet test tests/dotBento.WebApi.Tests
- dotnet test tests/dotBento.WebApi.Tests --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults/WebApiFinal
- dotnet reportgenerator -reports:"TestResults/WebApiFinal/**/coverage.cobertura.xml" -targetdir:"coverage-report-webapi" -reporttypes:"Html;TextSummary;Cobertura"
- dotnet test dotBento.sln