### PR TITLE
test: expand infrastructure coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ src/dotBento.sln.DotSettings.user
 TestResults/
 coverage-report/
 coverage-report-webapi/
+coverage-report-badges/
+coverage-report-infrastructure/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-72.2%25-yellow)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-90.6%25-brightgreen)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-46.2%25-orange)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-58.1%25-orange)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-95.9%25-brightgreen)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-99.7%25-brightgreen)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-58.1%25-orange)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-62.7%25-orange)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-90.6%25-brightgreen)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-95.6%25-brightgreen)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-71.1%25-yellow)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-71.9%25-yellow)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Build dotBento](https://github.com/thebentobot/dotBento/actions/workflows/dotnet.yml/badge.svg)](https://github.com/thebentobot/dotBento/actions/workflows/dotnet.yml)
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
+![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
+![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-46.2%25-orange)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 
@@ -73,14 +76,14 @@ Collect Coverlet coverage for all test projects:
 dotnet test dotBento.sln --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults
 ```
 
-Generate an HTML and text summary report:
+Generate an HTML, text summary, and local badge report:
 
 ```bash
 dotnet tool restore
-dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:"Html;TextSummary"
+dotnet reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:"Html;TextSummary;Badges"
 ```
 
-Open `coverage-report/index.html` for the full report, or read `coverage-report/Summary.txt` for a quick baseline.
+Open `coverage-report/index.html` for the full report, read `coverage-report/Summary.txt` for a quick baseline, or inspect the generated `coverage-report/badge_*.svg` files locally.
 
 ## Relevant links
 - The commit linting rules follows Conventional Commits. You can read about the linting rules specifically [here](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-70.5%25-yellow)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-71.1%25-yellow)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-71.9%25-yellow)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-72.2%25-yellow)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-62.7%25-orange)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-70.5%25-yellow)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Discord Bots](https://top.gg/api/widget/servers/787041583580184609.svg)](https://top.gg/bot/787041583580184609)
 ![dotBento.WebApi coverage](https://img.shields.io/badge/dotBento.WebApi%20coverage-100%25-brightgreen)
 ![dotBento.EntityFramework coverage](https://img.shields.io/badge/dotBento.EntityFramework%20coverage-99%25-brightgreen)
-![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-95.6%25-brightgreen)
+![dotBento.Infrastructure coverage](https://img.shields.io/badge/dotBento.Infrastructure%20coverage-95.9%25-brightgreen)
 
 A Discord bot written in .NET. This repository is the improved .NET rewrite of [Bento](https://github.com/thebentobot/Bento).
 

--- a/src/dotBento.Domain/Extensions/StringExtensions.cs
+++ b/src/dotBento.Domain/Extensions/StringExtensions.cs
@@ -16,7 +16,7 @@ public static class StringExtensions
 
     public static string FilterOutMentions(this string str)
     {
-        var pattern = new Regex("(@everyone|@here|<@|`|)");
+        var pattern = new Regex("(@everyone|@here|<@|`)");
         return pattern.Replace(str, "");
     }
     

--- a/src/dotBento.Infrastructure/Commands/GameCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/GameCommands.cs
@@ -4,12 +4,11 @@ using dotBento.Infrastructure.Services;
 
 namespace dotBento.Infrastructure.Commands;
 
-public sealed class GameCommands(GameService gameService)
+public sealed class GameCommands(GameService gameService, Func<int, int, int>? randomNext = null)
 {
     public async Task<(RpsGameChoice, RpsGameResult)> RockPaperScissorsAsync(RpsGameChoice playerChoice, long userId)
     {
-        var random = new Random();
-        var aiChoice = (RpsGameChoice) random.Next(0, 3);
+        var aiChoice = (RpsGameChoice)(randomNext?.Invoke(0, 3) ?? Random.Shared.Next(0, 3));
 
         RpsGameResult result;
 

--- a/src/dotBento.Infrastructure/Commands/ImageCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/ImageCommands.cs
@@ -42,6 +42,11 @@ public sealed class ImageCommands(SushiiImageServerService sushiiImageServerServ
             }
         }
 
+        if (rgbColour != null && rgbColour.Any(component => component is < 0 or > 255))
+        {
+            return Result.Failure<ColourResponseDto>("Please provide a valid RGB colour, e.g. `255,0,0`");
+        }
+
         if (hexColour != null)
         {
             var hexValue = int.Parse(hexColour, System.Globalization.NumberStyles.HexNumber);
@@ -49,11 +54,6 @@ public sealed class ImageCommands(SushiiImageServerService sushiiImageServerServ
             {
                 return Result.Failure<ColourResponseDto>("Please provide a valid hexcode, e.g. `#ff0000`");
             }
-        }
-
-        if (rgbColour != null && rgbColour.Any(component => component is < 0 or > 255))
-        {
-            return Result.Failure<ColourResponseDto>("Please provide a valid RGB colour, e.g. `255,0,0`");
         }
         
         var sanitizedHtml = htmlSanitizer.Sanitize($"<html><style>*{{margin:0;padding:0;}}</style><div style=\"background-color:{(hexColour != null ? $"#{hexColour}" : rgbColour)}; width:200px; height:200px\"></div></html>");

--- a/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using CSharpFunctionalExtensions;
 using Discord.WebSocket;
@@ -22,6 +23,7 @@ public sealed class ProfileCommands(
     private const ulong BentoSupportServerId = 714496317522444352;
     private const long DeveloperUserId = 232584569289703424;
 
+    [ExcludeFromCodeCoverage(Justification = "Discord.NET SocketGuildUser image entry point; GenerateProfileHtml covers the render workflow.")]
     public async Task<Result<Stream>> GetProfileAsync(string imageServerHost, string lastFmApiKey, long userId,
         long guildId, SocketGuildUser guildMember, int guildMemberCount, string botAvatarUrl)
     {

--- a/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
@@ -28,7 +28,19 @@ public sealed class ProfileCommands(
         var profileDb = await profileService.GetProfileAsync(userId);
         var profile = profileDb.HasValue ? MergeWithDefaults(profileDb.Value.Map()) : DefaultProfile(userId);
 
-        var html = GenerateProfileHtml(profile, lastFmApiKey, guildId, guildMember, guildMemberCount, botAvatarUrl);
+        var profileUser = new ProfileDiscordUser(
+            guildMember.GetDisplayAvatarUrl(),
+            guildMember.Discriminator,
+            guildMember.DisplayName,
+            guildMember.Nickname);
+        var html = GenerateProfileHtml(
+            profile,
+            lastFmApiKey,
+            guildId,
+            profileUser,
+            guildMemberCount,
+            botAvatarUrl,
+            guildMember);
 
         var image = await sushiiImageServerService
             .GetSushiiImage(imageServerHost, await html, 600, 400);
@@ -39,20 +51,22 @@ public sealed class ProfileCommands(
     }
 
     // TODO Improve this mess of arguments
-    private async Task<string> GenerateProfileHtml(
+    internal async Task<string> GenerateProfileHtml(
         Profile profile,
         string lastFmApiKey,
         long guildId,
-        SocketGuildUser guildMember,
+        ProfileDiscordUser guildMember,
         int guildUsersAmount,
-        string botAvatarUrl)
+        string botAvatarUrl,
+        SocketGuildUser? socketGuildMember = null)
     {
         var lastFmBoard = profile.LastfmBoard == true ? await GetLastFmNowPlayingHtml(profile, lastFmApiKey) : null;
         var xpBoard = profile.XpBoard == true ? await GetUserXpBoardHtml(profile, guildId, botAvatarUrl) : null;
         // TODO: Make one data method to avoid overfetching and make it more readable
         var bentoUser = userService.GetUserAsync((ulong)profile.UserId).Result.Value;
-        var bentoGuildUser = guildService
-            .GetOrCreateGuildMemberAsync((ulong)guildId, (ulong)profile.UserId, guildMember).Result.Value;
+        var bentoGuildUser = socketGuildMember is null
+            ? guildService.GetGuildMemberAsync((ulong)guildId, (ulong)profile.UserId).Result.Value
+            : guildService.GetOrCreateGuildMemberAsync((ulong)guildId, (ulong)profile.UserId, socketGuildMember).Result.Value;
         var bentoGameData = await bentoService.FindBentoAsync(profile.UserId);
         var bentoUserCount = await userService.GetTotalDiscordUserCountAsync();
         var bentoTotalUserCount = await bentoService.GetTotalCountOfBentoUsersAsync();
@@ -113,7 +127,7 @@ public sealed class ProfileCommands(
         var xpDoneGlobalColour3 =
             $"{profile.XpDoneGlobalColour3}{ConvertOpacityToHex(profile.XpDoneGlobalColour3Opacity)}";
 
-        var avatarUrl = guildMember.GetDisplayAvatarUrl() ??
+        var avatarUrl = guildMember.AvatarUrl ??
                         $"https://cdn.discordapp.com/embed/avatars/{int.Parse(guildMember.Discriminator ?? "0") % 5}.png";
         var usernameSlot = guildMember.DisplayName ?? "User";
         var discriminatorSlot = guildMember.Nickname ?? $"#{guildMember.Discriminator}";
@@ -1021,3 +1035,9 @@ public sealed class ProfileCommands(
 }
 
 public sealed record LastFmHtmlBoardResult(string LastFmHtml, int LastFmTrackLength, int LastFmArtistLength);
+
+internal sealed record ProfileDiscordUser(
+    string? AvatarUrl,
+    string? Discriminator,
+    string? DisplayName,
+    string? Nickname);

--- a/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/ProfileCommands.cs
@@ -63,10 +63,10 @@ public sealed class ProfileCommands(
         var lastFmBoard = profile.LastfmBoard == true ? await GetLastFmNowPlayingHtml(profile, lastFmApiKey) : null;
         var xpBoard = profile.XpBoard == true ? await GetUserXpBoardHtml(profile, guildId, botAvatarUrl) : null;
         // TODO: Make one data method to avoid overfetching and make it more readable
-        var bentoUser = userService.GetUserAsync((ulong)profile.UserId).Result.Value;
+        var bentoUser = (await userService.GetUserAsync((ulong)profile.UserId)).Value;
         var bentoGuildUser = socketGuildMember is null
-            ? guildService.GetGuildMemberAsync((ulong)guildId, (ulong)profile.UserId).Result.Value
-            : guildService.GetOrCreateGuildMemberAsync((ulong)guildId, (ulong)profile.UserId, socketGuildMember).Result.Value;
+            ? (await guildService.GetGuildMemberAsync((ulong)guildId, (ulong)profile.UserId)).Value
+            : (await guildService.GetOrCreateGuildMemberAsync((ulong)guildId, (ulong)profile.UserId, socketGuildMember)).Value;
         var bentoGameData = await bentoService.FindBentoAsync(profile.UserId);
         var bentoUserCount = await userService.GetTotalDiscordUserCountAsync();
         var bentoTotalUserCount = await bentoService.GetTotalCountOfBentoUsersAsync();

--- a/src/dotBento.Infrastructure/Commands/ReminderCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/ReminderCommands.cs
@@ -10,7 +10,8 @@ public sealed class ReminderCommands(ReminderService reminderService)
 {
     public async Task<Result> CreateReminderAsync(long userId, string content, DateTimeOffset date)
     {
-        var existsCheck = await reminderService.GetReminderAsync(userId, content, date);
+        var sanitizedContent = SanitizeTagContent(content);
+        var existsCheck = await reminderService.GetReminderAsync(userId, sanitizedContent, date);
         if (existsCheck.HasValue)
         {
             return Result.Failure("Reminder already exists.");
@@ -20,7 +21,6 @@ public sealed class ReminderCommands(ReminderService reminderService)
             return Result.Failure("Reminder date cannot be in the past.");
         }
         
-        var sanitizedContent = SanitizeTagContent(content);
         if (string.IsNullOrWhiteSpace(sanitizedContent))
         {
             return Result.Failure("Reminder content cannot be empty.");

--- a/src/dotBento.Infrastructure/Commands/TagCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/TagCommands.cs
@@ -65,8 +65,8 @@ public sealed class TagCommands(TagService tagService)
     
     public async Task<Result> RenameTagAsync(long userId, long guildId, string oldName, string newName, bool hasMessageEditPerms)
     {
-        var tagExistsCheck = await tagService.FindTagAsync(guildId, newName);
-        if (Constants.CommandNames.Contains(newName) || Constants.AliasNames.Contains(newName) || tagExistsCheck.HasValue)
+        var newTagExistsCheck = await tagService.FindTagAsync(guildId, newName);
+        if (Constants.CommandNames.Contains(newName) || Constants.AliasNames.Contains(newName) || newTagExistsCheck.HasValue)
         {
             return Result.Failure("New tag name cannot be an existing tag, Bento command name or Bento command alias.");
         }
@@ -74,7 +74,12 @@ public sealed class TagCommands(TagService tagService)
         {
             return Result.Failure("New tag name cannot be empty.");
         }
-        if (!hasMessageEditPerms || userId != tagExistsCheck.Value.UserId)
+        var oldTagExistsCheck = await tagService.FindTagAsync(guildId, oldName);
+        if (!oldTagExistsCheck.HasValue)
+        {
+            return Result.Failure("Tag not found.");
+        }
+        if (!hasMessageEditPerms || userId != oldTagExistsCheck.Value.UserId)
         {
             return Result.Failure("You can only rename your own tags.");
         }

--- a/src/dotBento.Infrastructure/Commands/TagCommands.cs
+++ b/src/dotBento.Infrastructure/Commands/TagCommands.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CSharpFunctionalExtensions;
 using dotBento.Domain;
 using dotBento.Domain.Entities.Tags;
@@ -110,6 +111,7 @@ public sealed class TagCommands(TagService tagService)
         return tag.HasValue ? Result.Success(tag.Value.ToBentoTag()) : Result.Failure<BentoTags>("No tags found.");
     }
     
+    [ExcludeFromCodeCoverage(Justification = "Wraps PostgreSQL ILike tag search methods that are not supported by the EF InMemory test provider.")]
     public async Task<Result<List<BentoTags>>> SearchTagsAsync(long guildId, string query)
     {
         var tagsByCommand = await tagService.SearchTagsByCommandAsync(guildId, query);

--- a/src/dotBento.Infrastructure/Services/GuildService.cs
+++ b/src/dotBento.Infrastructure/Services/GuildService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
@@ -57,6 +58,7 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
         }
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketGuild; internal overload covers the behavior.")]
     public async Task AddGuildAsync(SocketGuild guild)
     {
         await AddGuildAsync(guild.Id, guild.Name, guild.MemberCount);
@@ -82,6 +84,7 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
         }
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketGuildUser; internal overload covers the behavior.")]
     public async Task AddGuildMemberAsync(SocketGuildUser guildUser)
     {
         var avatarUrl = guildUser.GetGuildAvatarUrl(ImageFormat.Auto, 512) ??
@@ -189,6 +192,7 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
         return listOfGuildsForUser;
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketGuildUser; internal overload covers the behavior.")]
     public async Task UpdateGuildMemberAvatarAsync(SocketGuildUser guildMember)
     {
         var avatarUrl = guildMember.GetGuildAvatarUrl(ImageFormat.Auto, 512) ??
@@ -256,6 +260,7 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
         }
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketGuildUser; internal overload covers the behavior.")]
     public async Task<Maybe<GuildMember>> GetOrCreateGuildMemberAsync(ulong discordGuildId, ulong discordUserId,
         SocketGuildUser guildUser)
     {

--- a/src/dotBento.Infrastructure/Services/GuildService.cs
+++ b/src/dotBento.Infrastructure/Services/GuildService.cs
@@ -59,17 +59,22 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
 
     public async Task AddGuildAsync(SocketGuild guild)
     {
+        await AddGuildAsync(guild.Id, guild.Name, guild.MemberCount);
+    }
+
+    internal async Task AddGuildAsync(ulong guildId, string name, int memberCount)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
-        var databaseGuild = await db.Guilds.AsQueryable().FirstOrDefaultAsync(f => f.GuildId == (long)guild.Id);
+        var databaseGuild = await db.Guilds.AsQueryable().FirstOrDefaultAsync(f => f.GuildId == (long)guildId);
 
         if (databaseGuild == null)
         {
             databaseGuild = new Guild
             {
-                GuildId = (long)guild.Id,
+                GuildId = (long)guildId,
                 Prefix = Constants.StartPrefix,
-                GuildName = guild.Name,
-                MemberCount = guild.MemberCount,
+                GuildName = name,
+                MemberCount = memberCount,
             };
             await db.Guilds.AddAsync(databaseGuild);
             await db.SaveChangesAsync();
@@ -79,18 +84,25 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
 
     public async Task AddGuildMemberAsync(SocketGuildUser guildUser)
     {
+        var avatarUrl = guildUser.GetGuildAvatarUrl(ImageFormat.Auto, 512) ??
+                        guildUser.GetDisplayAvatarUrl(ImageFormat.Auto, 512);
+        await AddGuildMemberAsync(guildUser.Guild.Id, guildUser.Id, avatarUrl);
+    }
+
+    internal async Task AddGuildMemberAsync(ulong guildId, ulong userId, string? avatarUrl)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var guildMember = await db.GuildMembers
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.GuildId == (long)guildUser.Guild.Id && f.UserId == (long)guildUser.Id);
+            .FirstOrDefaultAsync(f => f.GuildId == (long)guildId && f.UserId == (long)userId);
 
         if (guildMember == null)
         {
             guildMember = new GuildMember
             {
-                GuildId = (long)guildUser.Guild.Id,
-                UserId = (long)guildUser.Id,
-                AvatarUrl = guildUser.GetGuildAvatarUrl(ImageFormat.Auto, 512) ?? guildUser.GetDisplayAvatarUrl(ImageFormat.Auto, 512),
+                GuildId = (long)guildId,
+                UserId = (long)userId,
+                AvatarUrl = avatarUrl,
                 Xp = 0,
                 Level = 1
             };
@@ -179,14 +191,21 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
 
     public async Task UpdateGuildMemberAvatarAsync(SocketGuildUser guildMember)
     {
+        var avatarUrl = guildMember.GetGuildAvatarUrl(ImageFormat.Auto, 512) ??
+                        guildMember.GetDisplayAvatarUrl(ImageFormat.Auto, 512);
+        await UpdateGuildMemberAvatarAsync(guildMember.Guild.Id, guildMember.Id, avatarUrl);
+    }
+
+    internal async Task UpdateGuildMemberAvatarAsync(ulong guildId, ulong userId, string? avatarUrl)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var user = await db.GuildMembers
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)guildMember.Id && f.GuildId == (long)guildMember.Guild.Id);
+            .FirstOrDefaultAsync(f => f.UserId == (long)userId && f.GuildId == (long)guildId);
 
         if (user != null)
         {
-            user.AvatarUrl = guildMember.GetGuildAvatarUrl(ImageFormat.Auto, 512) ?? guildMember.GetDisplayAvatarUrl(ImageFormat.Auto, 512);
+            user.AvatarUrl = avatarUrl;
             await db.SaveChangesAsync();
             await RemoveGuildMemberFromCache((ulong)user.GuildId, (ulong)user.UserId);
             await AddGuildMemberToCache(user);
@@ -240,6 +259,16 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
     public async Task<Maybe<GuildMember>> GetOrCreateGuildMemberAsync(ulong discordGuildId, ulong discordUserId,
         SocketGuildUser guildUser)
     {
+        var avatarUrl = guildUser.GetGuildAvatarUrl(ImageFormat.Auto, 512) ??
+                        guildUser.GetDisplayAvatarUrl(ImageFormat.Auto, 512);
+        return await GetOrCreateGuildMemberAsync(discordGuildId, discordUserId, avatarUrl);
+    }
+
+    internal async Task<Maybe<GuildMember>> GetOrCreateGuildMemberAsync(
+        ulong discordGuildId,
+        ulong discordUserId,
+        string? avatarUrl)
+    {
         var cachedKey = CacheKeyForGuildMember(discordGuildId, discordUserId);
         if (cache.TryGetValue(cachedKey, out GuildMember? cachedGuildMember))
         {
@@ -262,7 +291,7 @@ public sealed class GuildService(IDbContextFactory<BotDbContext> contextFactory,
         {
             GuildId = (long)discordGuildId,
             UserId = (long)discordUserId,
-            AvatarUrl = guildUser.GetGuildAvatarUrl(ImageFormat.Auto, 512) ?? guildUser.GetDisplayAvatarUrl(ImageFormat.Auto, 512),
+            AvatarUrl = avatarUrl,
             Xp = 0,
             Level = 1
         };

--- a/src/dotBento.Infrastructure/Services/PrefixService.cs
+++ b/src/dotBento.Infrastructure/Services/PrefixService.cs
@@ -3,7 +3,6 @@ using dotBento.Domain;
 using dotBento.EntityFramework.Context;
 using dotBento.Infrastructure.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using Serilog;
 
 namespace dotBento.Infrastructure.Services;
 
@@ -13,21 +12,7 @@ public sealed class PrefixService(IDbContextFactory<BotDbContext> contextFactory
 
     public void StorePrefix(string prefix, ulong key)
     {
-        if (ServerPrefixes.ContainsKey(key))
-        {
-            var oldPrefix = GetPrefix(key);
-            if (!ServerPrefixes.TryUpdate(key, prefix, oldPrefix))
-            {
-                Log.Warning("Failed to update custom prefix {Prefix} with the key: {Key} from the dictionary", prefix, key);
-            }
-
-            return;
-        }
-
-        if (!ServerPrefixes.TryAdd(key, prefix))
-        {
-            Log.Warning("Failed to add custom prefix {Prefix} with the key: {Key} from the dictionary", prefix, key);
-        }
+        ServerPrefixes.AddOrUpdate(key, prefix, (_, _) => prefix);
     }
 
 
@@ -50,10 +35,7 @@ public sealed class PrefixService(IDbContextFactory<BotDbContext> contextFactory
             return;
         }
 
-        if (!ServerPrefixes.TryRemove(key, out var removedPrefix))
-        {
-            Log.Warning("Failed to remove custom prefix {RemovedPrefix} with the key: {Key} from the dictionary", removedPrefix, key);
-        }
+        ServerPrefixes.TryRemove(key, out _);
     }
 
 

--- a/src/dotBento.Infrastructure/Services/TagService.cs
+++ b/src/dotBento.Infrastructure/Services/TagService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CSharpFunctionalExtensions;
 using dotBento.EntityFramework.Context;
 using dotBento.EntityFramework.Entities;
@@ -151,6 +152,7 @@ public sealed class TagService(
         InvalidateTagCache(tag.GuildId, tag.Command);
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Uses PostgreSQL ILike, which is not supported by the EF InMemory test provider.")]
     public async Task<List<Tag>> SearchTagsByCommandAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();
@@ -160,6 +162,7 @@ public sealed class TagService(
             .ToListAsync();
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Uses PostgreSQL ILike, which is not supported by the EF InMemory test provider.")]
     public async Task<List<Tag>> SearchTagsByContentAsync(long guildId, string query)
     {
         await using var context = await contextFactory.CreateDbContextAsync();

--- a/src/dotBento.Infrastructure/Services/UserService.cs
+++ b/src/dotBento.Infrastructure/Services/UserService.cs
@@ -112,6 +112,11 @@ public sealed class UserService(IMemoryCache cache,
 
     public async Task CreateOrAddUserToCache(SocketUser discordUser)
     {
+        await CreateOrAddUserToCache((IUser)discordUser);
+    }
+
+    internal async Task CreateOrAddUserToCache(IUser discordUser)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var databaseUser = await db.Users
             .AsQueryable()
@@ -138,40 +143,24 @@ public sealed class UserService(IMemoryCache cache,
     
     public async Task CreateOrAddUserToCache(SocketGuildUser discordUser)
     {
-        await using var db = await contextFactory.CreateDbContextAsync();
-        var databaseUser = await db.Users
-            .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)discordUser.Id);
-
-        if (databaseUser == null)
-        {
-            databaseUser = new User
-            {
-                UserId = (long)discordUser.Id,
-                Username = discordUser.Username,
-                Discriminator = discordUser.Discriminator,
-                AvatarUrl = discordUser.GetAvatarUrl(ImageFormat.Auto, 512),
-                Level = 1,
-                Xp = 0
-            };
-
-            db.Users.Add(databaseUser);
-            await db.SaveChangesAsync();
-        }
-        
-        await AddUserToCache(databaseUser);
+        await CreateOrAddUserToCache((IUser)discordUser);
     }
 
     public async Task UpdateUserAvatarAsync(SocketUser newUser)
     {
+        await UpdateUserAvatarAsync(newUser.Id, newUser.GetAvatarUrl(ImageFormat.Auto, 512));
+    }
+
+    internal async Task UpdateUserAvatarAsync(ulong userId, string? avatarUrl)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var user = await db.Users
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)newUser.Id);
+            .FirstOrDefaultAsync(f => f.UserId == (long)userId);
 
         if (user != null)
         {
-            user.AvatarUrl = newUser.GetAvatarUrl(ImageFormat.Auto, 512);
+            user.AvatarUrl = avatarUrl;
             await db.SaveChangesAsync();
             RemoveUserFromCache(user);
             await AddUserToCache(user);
@@ -180,14 +169,19 @@ public sealed class UserService(IMemoryCache cache,
 
     public async Task UpdateUserUsernameAsync(SocketUser newUser)
     {
+        await UpdateUserUsernameAsync(newUser.Id, newUser.Username);
+    }
+
+    internal async Task UpdateUserUsernameAsync(ulong userId, string username)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var user = await db.Users
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)newUser.Id);
+            .FirstOrDefaultAsync(f => f.UserId == (long)userId);
 
         if (user != null)
         {
-            user.Username = newUser.Username;
+            user.Username = username;
             await db.SaveChangesAsync();
             RemoveUserFromCache(user);
             await AddUserToCache(user);
@@ -223,13 +217,18 @@ public sealed class UserService(IMemoryCache cache,
 
     public async Task AddExperienceAsync(SocketCommandContext context, Maybe<Patreon> patreonUser)
     {
+        await AddExperienceAsync(context.User.Id, context.Guild.Id, patreonUser);
+    }
+
+    internal async Task AddExperienceAsync(ulong userId, ulong guildId, Maybe<Patreon> patreonUser)
+    {
         await using var db = await contextFactory.CreateDbContextAsync();
         var user = await db.Users
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)context.User.Id);
+            .FirstOrDefaultAsync(f => f.UserId == (long)userId);
         var guildMember = await db.GuildMembers
             .AsQueryable()
-            .FirstOrDefaultAsync(f => f.UserId == (long)context.User.Id && f.GuildId == (long)context.Guild.Id);
+            .FirstOrDefaultAsync(f => f.UserId == (long)userId && f.GuildId == (long)guildId);
         
         if (user == null || guildMember == null) return;
 

--- a/src/dotBento.Infrastructure/Services/UserService.cs
+++ b/src/dotBento.Infrastructure/Services/UserService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using CSharpFunctionalExtensions;
 using Discord;
 using Discord.Commands;
@@ -110,6 +111,7 @@ public sealed class UserService(IMemoryCache cache,
         }
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketUser; IUser overload covers the behavior.")]
     public async Task CreateOrAddUserToCache(SocketUser discordUser)
     {
         await CreateOrAddUserToCache((IUser)discordUser);
@@ -141,11 +143,13 @@ public sealed class UserService(IMemoryCache cache,
         await AddUserToCache(databaseUser);
     }
     
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketGuildUser; IUser overload covers the behavior.")]
     public async Task CreateOrAddUserToCache(SocketGuildUser discordUser)
     {
         await CreateOrAddUserToCache((IUser)discordUser);
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketUser; internal overload covers the behavior.")]
     public async Task UpdateUserAvatarAsync(SocketUser newUser)
     {
         await UpdateUserAvatarAsync(newUser.Id, newUser.GetAvatarUrl(ImageFormat.Auto, 512));
@@ -167,6 +171,7 @@ public sealed class UserService(IMemoryCache cache,
         }
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketUser; internal overload covers the behavior.")]
     public async Task UpdateUserUsernameAsync(SocketUser newUser)
     {
         await UpdateUserUsernameAsync(newUser.Id, newUser.Username);
@@ -215,6 +220,7 @@ public sealed class UserService(IMemoryCache cache,
         return maybeUser;
     }
 
+    [ExcludeFromCodeCoverage(Justification = "Thin adapter over Discord.NET SocketCommandContext; internal overload covers the behavior.")]
     public async Task AddExperienceAsync(SocketCommandContext context, Maybe<Patreon> patreonUser)
     {
         await AddExperienceAsync(context.User.Id, context.Guild.Id, patreonUser);

--- a/tests/dotBento.Infrastructure.Tests/Commands/GameCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/GameCommandsTests.cs
@@ -7,26 +7,22 @@ namespace dotBento.Infrastructure.Tests.Commands;
 
 public sealed class GameCommandsTests
 {
-    [Fact]
-    public async Task RockPaperScissorsAsync_ReturnsValidAiChoiceAndPersistsOneResult()
+    [Theory]
+    [InlineData(RpsGameChoice.Rock, RpsGameChoice.Scissors, RpsGameResult.Win)]
+    [InlineData(RpsGameChoice.Rock, RpsGameChoice.Paper, RpsGameResult.Loss)]
+    [InlineData(RpsGameChoice.Rock, RpsGameChoice.Rock, RpsGameResult.Draw)]
+    public async Task RockPaperScissorsAsync_ReturnsExpectedResultAndPersistsStats(
+        RpsGameChoice playerChoice,
+        RpsGameChoice aiChoice,
+        RpsGameResult expectedResult)
     {
         var factory = new InfrastructureTestDbFactory();
-        var command = new GameCommands(new GameService(factory));
+        var command = new GameCommands(new GameService(factory), (_, _) => (int)aiChoice);
 
-        var (aiChoice, result) = await command.RockPaperScissorsAsync(RpsGameChoice.Rock, 100);
+        var (actualAiChoice, result) = await command.RockPaperScissorsAsync(playerChoice, 100);
 
-        Assert.Contains(aiChoice, new[]
-        {
-            RpsGameChoice.Rock,
-            RpsGameChoice.Paper,
-            RpsGameChoice.Scissors
-        });
-        Assert.Contains(result, new[]
-        {
-            RpsGameResult.Win,
-            RpsGameResult.Loss,
-            RpsGameResult.Draw
-        });
+        Assert.Equal(aiChoice, actualAiChoice);
+        Assert.Equal(expectedResult, result);
 
         await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         var stats = await db.RpsGames.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);

--- a/tests/dotBento.Infrastructure.Tests/Commands/GameCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/GameCommandsTests.cs
@@ -1,0 +1,52 @@
+using dotBento.Domain.Enums.Games;
+using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace dotBento.Infrastructure.Tests.Commands;
+
+public sealed class GameCommandsTests
+{
+    [Fact]
+    public async Task RockPaperScissorsAsync_ReturnsValidAiChoiceAndPersistsOneResult()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var command = new GameCommands(new GameService(factory));
+
+        var (aiChoice, result) = await command.RockPaperScissorsAsync(RpsGameChoice.Rock, 100);
+
+        Assert.Contains(aiChoice, new[]
+        {
+            RpsGameChoice.Rock,
+            RpsGameChoice.Paper,
+            RpsGameChoice.Scissors
+        });
+        Assert.Contains(result, new[]
+        {
+            RpsGameResult.Win,
+            RpsGameResult.Loss,
+            RpsGameResult.Draw
+        });
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var stats = await db.RpsGames.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var total = (stats.RockWins ?? 0) + (stats.RockLosses ?? 0) + (stats.RockTies ?? 0);
+        Assert.Equal(1, total);
+    }
+
+    [Fact]
+    public void MagicEightBallResponse_ReturnsAResponse()
+    {
+        var response = GameCommands.MagicEightBallResponse();
+
+        Assert.False(string.IsNullOrWhiteSpace(response));
+    }
+
+    [Fact]
+    public void Roll_ReturnsValueWithinRange()
+    {
+        var roll = GameCommands.Roll(1, 7);
+
+        Assert.InRange(roll, 1, 6);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Commands/ImageCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/ImageCommandsTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services.Api;
+using Ganss.Xss;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Commands;
+
+public sealed class ImageCommandsTests
+{
+    [Theory]
+    [InlineData("#ff0000", true)]
+    [InlineData("0x00ff00", true)]
+    [InlineData("0, 0, 255", false)]
+    public async Task GetColour_ReturnsImageForValidColours(string colour, bool expectedHexInput)
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StreamContent(new MemoryStream([1, 2, 3]))
+        });
+        var command = new ImageCommands(new SushiiImageServerService(httpClient), new HtmlSanitizer());
+
+        var result = await command.GetColour("https://image.example/render", colour);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedHexInput, result.Value.IsHex);
+        await result.Value.Image.DisposeAsync();
+    }
+
+    [Theory]
+    [InlineData("not-a-colour", "valid hexcode or RGB colour")]
+    [InlineData("999, 0, 0", "valid hexcode")]
+    public async Task GetColour_ReturnsValidationFailureForInvalidColours(string colour, string expectedError)
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+        var command = new ImageCommands(new SushiiImageServerService(httpClient), new HtmlSanitizer());
+
+        var result = await command.GetColour("https://image.example/render", colour);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(expectedError, result.Error);
+    }
+
+    [Fact]
+    public async Task GetColour_ReturnsFailureWhenImageServerFails()
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError });
+        var command = new ImageCommands(new SushiiImageServerService(httpClient), new HtmlSanitizer());
+
+        var result = await command.GetColour("https://image.example/render", "#ffffff");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("Could not get image from Sushii Image Server", result.Error);
+    }
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        return new HttpClient(mockHandler.Object);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Commands/ImageCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/ImageCommandsTests.cs
@@ -31,7 +31,8 @@ public sealed class ImageCommandsTests
 
     [Theory]
     [InlineData("not-a-colour", "valid hexcode or RGB colour")]
-    [InlineData("999, 0, 0", "valid hexcode")]
+    [InlineData("999, 0, 0", "valid RGB colour")]
+    [InlineData("999,0,0", "valid RGB colour")]
     public async Task GetColour_ReturnsValidationFailureForInvalidColours(string colour, string expectedError)
     {
         using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });

--- a/tests/dotBento.Infrastructure.Tests/Commands/LastFmCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/LastFmCommandsTests.cs
@@ -1,0 +1,317 @@
+using System.Net;
+using dotBento.Domain.Entities.LastFm;
+using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services.Api;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Commands;
+
+public sealed class LastFmCommandsTests
+{
+    [Fact]
+    public async Task LastFmCommands_MapSuccessfulApiResponses()
+    {
+        using var lastFmClient = CreateHttpClient(
+            JsonResponse("""
+            {
+              "topartists": {
+                "artist": [
+                  {
+                    "streamable": "0",
+                    "mbid": null,
+                    "name": "Artist",
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "url": "https://last.fm/artist",
+                    "@attr": { "rank": "1" },
+                    "playcount": "12"
+                  }
+                ],
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "1", "perPage": "1" }
+              }
+            }
+            """),
+            JsonResponse("""
+            {
+              "topalbums": {
+                "album": [
+                  {
+                    "mbid": null,
+                    "name": "Album",
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "artist": { "url": null, "mbid": null, "name": "Artist" },
+                    "url": "https://last.fm/album",
+                    "@attr": { "rank": "2" },
+                    "playcount": "34"
+                  }
+                ]
+              }
+            }
+            """),
+            JsonResponse("""
+            {
+              "toptracks": {
+                "track": [
+                  {
+                    "streamable": { "#text": "0", "fulltrack": "0" },
+                    "mbid": null,
+                    "name": "Track",
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "artist": { "url": null, "mbid": null, "name": "Artist" },
+                    "url": "https://last.fm/track",
+                    "duration": "123",
+                    "@attr": { "rank": "3" },
+                    "playcount": "56"
+                  }
+                ],
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "1", "perPage": "1" }
+              }
+            }
+            """),
+            JsonResponse("""
+            {
+              "recenttracks": {
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "9", "perPage": "2" },
+                "track": [
+                  {
+                    "@attr": { "nowplaying": "true" },
+                    "mbid": null,
+                    "loved": null,
+                    "artist": { "url": null, "mbid": null, "#text": "Artist" },
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "date": null,
+                    "url": "https://last.fm/now",
+                    "name": "Now",
+                    "album": { "mbid": null, "#text": "Album" }
+                  },
+                  {
+                    "mbid": null,
+                    "loved": null,
+                    "artist": { "url": null, "mbid": null, "#text": "Artist" },
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "date": { "uts": "60", "#text": "date" },
+                    "url": "https://last.fm/old",
+                    "name": "Old",
+                    "album": { "mbid": null, "#text": "Album" }
+                  }
+                ]
+              }
+            }
+            """),
+            JsonResponse("""
+            {
+              "recenttracks": {
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "2", "perPage": "50" },
+                "track": [
+                  {
+                    "mbid": null,
+                    "loved": null,
+                    "artist": { "url": null, "mbid": null, "#text": "Artist" },
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "date": { "uts": "60", "#text": "date" },
+                    "url": "https://last.fm/old",
+                    "name": "Old",
+                    "album": { "mbid": null, "#text": "Album" }
+                  }
+                ]
+              }
+            }
+            """),
+            JsonResponse("""
+            {
+              "user": {
+                "name": "listener",
+                "age": "0",
+                "subscriber": "0",
+                "realname": "Listener",
+                "bootstrap": "0",
+                "playcount": "100",
+                "artist_count": "20",
+                "playlists": "0",
+                "track_count": "30",
+                "album_count": "10",
+                "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                "registered": { "unixtime": "60", "#text": 60 },
+                "country": "DK",
+                "gender": "n",
+                "url": "https://last.fm/user/listener",
+                "type": "user"
+              }
+            }
+            """));
+        var command = CreateCommand(lastFmClient);
+
+        var artists = await command.GetTopArtists("listener", "api-key", "7day");
+        var albums = await command.GetTopAlbums("listener", "api-key", "7day");
+        var tracks = await command.GetTopTracks("listener", "api-key", "7day");
+        var nowPlaying = await command.NowPlaying("listener", "api-key");
+        var recentTracks = await command.GetRecentTracks("listener", "api-key");
+        var userInfo = await command.GetUserInfo("listener", "api-key");
+
+        Assert.True(artists.IsSuccess);
+        Assert.Equal(("Artist", "large.png", 12, 1),
+            (artists.Value.Single().Name, artists.Value.Single().ImageUrl, artists.Value.Single().PlayCount, artists.Value.Single().Rank));
+        Assert.True(albums.IsSuccess);
+        Assert.Equal(("Album", "Artist", 34, 2),
+            (albums.Value.Single().Name, albums.Value.Single().Artist, albums.Value.Single().PlayCount, albums.Value.Single().Rank));
+        Assert.True(tracks.IsSuccess);
+        Assert.Equal(("Track", "Artist", 56, 3),
+            (tracks.Value.Single().Name, tracks.Value.Single().Artist, tracks.Value.Single().PlayCount, tracks.Value.Single().Rank));
+        Assert.True(nowPlaying.IsSuccess);
+        Assert.Equal(9, nowPlaying.Value.TotalTracks);
+        Assert.Equal(["Now", "Old"], nowPlaying.Value.RecentTracks.Select(track => track.Track));
+        Assert.True(recentTracks.IsSuccess);
+        Assert.Equal("Old", recentTracks.Value.Single().Track);
+        Assert.True(userInfo.IsSuccess);
+        Assert.Equal(("listener", "large.png", 100, 20, 10, 30),
+            (userInfo.Value.Name, userInfo.Value.ImageUrl, userInfo.Value.PlayCount, userInfo.Value.ArtistCount,
+                userInfo.Value.AlbumCount, userInfo.Value.TrackCount));
+    }
+
+    [Theory]
+    [InlineData(nameof(GetTopArtistsFailure))]
+    [InlineData(nameof(GetTopAlbumsFailure))]
+    [InlineData(nameof(GetTopTracksFailure))]
+    [InlineData(nameof(NowPlayingFailure))]
+    [InlineData(nameof(GetRecentTracksFailure))]
+    [InlineData(nameof(GetUserInfoFailure))]
+    public async Task LastFmCommands_PropagateApiFailures(string method)
+    {
+        using var lastFmClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.Forbidden });
+        var command = CreateCommand(lastFmClient);
+
+        var result = method switch
+        {
+            nameof(GetTopArtistsFailure) => (await command.GetTopArtists("listener", "bad-key", "7day")).Error,
+            nameof(GetTopAlbumsFailure) => (await command.GetTopAlbums("listener", "bad-key", "7day")).Error,
+            nameof(GetTopTracksFailure) => (await command.GetTopTracks("listener", "bad-key", "7day")).Error,
+            nameof(NowPlayingFailure) => (await command.NowPlaying("listener", "bad-key")).Error,
+            nameof(GetRecentTracksFailure) => (await command.GetRecentTracks("listener", "bad-key")).Error,
+            nameof(GetUserInfoFailure) => (await command.GetUserInfo("listener", "bad-key")).Error,
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+        };
+
+        Assert.Contains("403 Forbidden", result);
+    }
+
+    [Fact]
+    public async Task LastFmCommands_ReturnFailuresForMissingPayloadSections()
+    {
+        using var lastFmClient = CreateHttpClient(
+            JsonResponse("""{ "topartists": null }"""),
+            JsonResponse("""{ "topalbums": null }"""),
+            JsonResponse("""{ "toptracks": null }"""),
+            JsonResponse("""{ "recenttracks": null }"""),
+            JsonResponse("""{ "recenttracks": null }"""),
+            JsonResponse("""{ "user": null }"""));
+        var command = CreateCommand(lastFmClient);
+
+        var artists = await command.GetTopArtists("listener", "api-key", "7day");
+        var albums = await command.GetTopAlbums("listener", "api-key", "7day");
+        var tracks = await command.GetTopTracks("listener", "api-key", "7day");
+        var nowPlaying = await command.NowPlaying("listener", "api-key");
+        var recentTracks = await command.GetRecentTracks("listener", "api-key");
+        var userInfo = await command.GetUserInfo("listener", "api-key");
+
+        Assert.Equal("No top artists found", artists.Error);
+        Assert.Equal("No top albums found", albums.Error);
+        Assert.Equal("No top tracks found", tracks.Error);
+        Assert.Equal("No recent tracks found", nowPlaying.Error);
+        Assert.Equal("No recent tracks found", recentTracks.Error);
+        Assert.Equal("No user info found", userInfo.Error);
+    }
+
+    [Fact]
+    public async Task GetLastFmCollageImage_RendersExpectedGridDimensions()
+    {
+        HttpRequestMessage? request = null;
+        string? requestBody = null;
+        using var sushiiClient = CreateHttpClient(
+            new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StreamContent(new MemoryStream([1, 2, 3]))
+            },
+            message =>
+            {
+                request = message;
+                requestBody = message.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
+            });
+        var command = CreateCommand(CreateHttpClient(), sushiiClient);
+        var collage = Enumerable.Range(1, 12)
+            .Select(i => new BentoLastFmCollage($"https://img.example/{i}.png", $"Artist {i}", i, $"Name {i}"))
+            .ToList();
+
+        var result = await command.GetLastFmCollageImage("3x3", collage, "https://image.example/render");
+
+        Assert.True(result.IsSuccess);
+        await result.Value.DisposeAsync();
+        Assert.NotNull(request);
+        Assert.Contains(@"""width"":""900""", requestBody);
+        Assert.Contains(@"""height"":""900""", requestBody);
+        Assert.Contains("Artist 9", requestBody);
+        Assert.DoesNotContain("Artist 10", requestBody);
+    }
+
+    [Fact]
+    public async Task GetLastFmCollageImage_ReturnsFailureWhenImageServerFails()
+    {
+        using var sushiiClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.InternalServerError });
+        var command = CreateCommand(CreateHttpClient(), sushiiClient);
+
+        var result = await command.GetLastFmCollageImage(
+            "2x2",
+            [new BentoLastFmCollage("https://img.example/1.png", "Artist", 1, null)],
+            "https://image.example/render");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("Could not get image from Sushii Image Server", result.Error);
+    }
+
+    private const string GetTopArtistsFailure = nameof(GetTopArtistsFailure);
+    private const string GetTopAlbumsFailure = nameof(GetTopAlbumsFailure);
+    private const string GetTopTracksFailure = nameof(GetTopTracksFailure);
+    private const string NowPlayingFailure = nameof(NowPlayingFailure);
+    private const string GetRecentTracksFailure = nameof(GetRecentTracksFailure);
+    private const string GetUserInfoFailure = nameof(GetUserInfoFailure);
+
+    private static LastFmCommands CreateCommand(HttpClient lastFmClient, HttpClient? sushiiClient = null) =>
+        new(new LastFmApiService(lastFmClient),
+            new SushiiImageServerService(sushiiClient ?? CreateHttpClient()));
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new()
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+
+    private static HttpClient CreateHttpClient(params HttpResponseMessage[] responses) =>
+        CreateHttpClient(responses, _ => { });
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response, Action<HttpRequestMessage> captureRequest) =>
+        CreateHttpClient([response], captureRequest);
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage[] responses, Action<HttpRequestMessage> captureRequest)
+    {
+        var queue = new Queue<HttpResponseMessage>(responses);
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                captureRequest(request);
+                return queue.Count > 0
+                    ? queue.Dequeue()
+                    : new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent("{}") };
+            });
+
+        return new HttpClient(mockHandler.Object);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Commands/ReminderCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/ReminderCommandsTests.cs
@@ -1,0 +1,117 @@
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace dotBento.Infrastructure.Tests.Commands;
+
+public sealed class ReminderCommandsTests
+{
+    [Fact]
+    public async Task CreateReminderAsync_ValidatesAndCreatesReminder()
+    {
+        var command = CreateCommand(out var factory);
+        var date = DateTimeOffset.UtcNow.AddHours(1);
+
+        var created = await command.CreateReminderAsync(100, " hello #tag ", date);
+        var duplicate = await command.CreateReminderAsync(100, " hello #tag ", date);
+        var pastDate = await command.CreateReminderAsync(100, "past", DateTimeOffset.UtcNow.AddHours(-1));
+        var empty = await command.CreateReminderAsync(100, "   ", date.AddHours(1));
+
+        Assert.True(created.IsSuccess);
+        Assert.True(duplicate.IsFailure);
+        Assert.Equal("Reminder already exists.", duplicate.Error);
+        Assert.True(pastDate.IsFailure);
+        Assert.True(empty.IsFailure);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var reminder = Assert.Single(db.Reminders);
+        Assert.Equal(@" hello \#tag ", reminder.Reminder1);
+    }
+
+    [Fact]
+    public async Task DeleteUpdateAndGetReminderAsync_ValidateAndPersistChanges()
+    {
+        var command = CreateCommand(out var factory);
+        var reminder = await SeedReminderAsync(factory, 100, "original", DateTime.UtcNow.AddHours(1));
+
+        var missing = await command.GetReminderAsync(100, 999);
+        var found = await command.GetReminderAsync(100, reminder.Id);
+        var noChanges = await command.UpdateReminderAsync(100, reminder.Id, null, null);
+        var pastDate = await command.UpdateReminderAsync(100, reminder.Id, null, DateTimeOffset.UtcNow.AddHours(-1));
+        var emptyContent = await command.UpdateReminderAsync(100, reminder.Id, "   ", null);
+        var updateMissing = await command.UpdateReminderAsync(100, 999, "updated", null);
+        var updated = await command.UpdateReminderAsync(100, reminder.Id, "updated", DateTimeOffset.UtcNow.AddHours(2));
+        var afterUpdate = await command.GetReminderAsync(100, reminder.Id);
+        var deleteMissing = await command.DeleteReminderAsync(100, 999);
+        var deleted = await command.DeleteReminderAsync(100, reminder.Id);
+        var afterDelete = await command.GetReminderAsync(100, reminder.Id);
+
+        Assert.True(missing.IsFailure);
+        Assert.True(found.IsSuccess);
+        Assert.True(noChanges.IsFailure);
+        Assert.True(pastDate.IsFailure);
+        Assert.True(emptyContent.IsFailure);
+        Assert.True(updateMissing.IsFailure);
+        Assert.True(updated.IsSuccess);
+        Assert.Equal("updated", afterUpdate.Value.Content);
+        Assert.True(deleteMissing.IsFailure);
+        Assert.True(deleted.IsSuccess);
+        Assert.True(afterDelete.IsFailure);
+    }
+
+    [Fact]
+    public async Task GetRemindersAsync_ReturnsOrderedRemindersOrFailureWhenEmpty()
+    {
+        var command = CreateCommand(out var factory);
+        var empty = await command.GetRemindersAsync(100);
+        await SeedReminderAsync(factory, 100, "later", DateTime.UtcNow.AddHours(2));
+        await SeedReminderAsync(factory, 100, "sooner", DateTime.UtcNow.AddHours(1));
+
+        var result = await command.GetRemindersAsync(100);
+
+        Assert.True(empty.IsFailure);
+        Assert.True(result.IsSuccess);
+        Assert.Equal(["sooner", "later"], result.Value.Select(reminder => reminder.Content));
+    }
+
+    [Fact]
+    public async Task GetAllRecentRemindersAsync_ReturnsPastRemindersOrFailureWhenEmpty()
+    {
+        var command = CreateCommand(out var factory);
+        var empty = await command.GetAllRecentRemindersAsync();
+        await SeedReminderAsync(factory, 100, "past", DateTime.UtcNow.AddMinutes(-1));
+        await SeedReminderAsync(factory, 100, "future", DateTime.UtcNow.AddMinutes(10));
+
+        var result = await command.GetAllRecentRemindersAsync();
+
+        Assert.True(empty.IsFailure);
+        Assert.True(result.IsSuccess);
+        var reminder = Assert.Single(result.Value);
+        Assert.Equal("past", reminder.Content);
+    }
+
+    private static ReminderCommands CreateCommand(out InfrastructureTestDbFactory factory)
+    {
+        factory = new InfrastructureTestDbFactory();
+        return new ReminderCommands(new ReminderService(new MemoryCache(new MemoryCacheOptions()), factory));
+    }
+
+    private static async Task<Reminder> SeedReminderAsync(
+        InfrastructureTestDbFactory factory,
+        long userId,
+        string content,
+        DateTime date)
+    {
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var reminder = new Reminder
+        {
+            UserId = userId,
+            Reminder1 = content,
+            Date = date
+        };
+        db.Reminders.Add(reminder);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return reminder;
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Commands/TagCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Commands/TagCommandsTests.cs
@@ -1,0 +1,140 @@
+using CSharpFunctionalExtensions;
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace dotBento.Infrastructure.Tests.Commands;
+
+public sealed class TagCommandsTests
+{
+    [Fact]
+    public async Task CreateTagAsync_ValidatesAndCreatesTags()
+    {
+        var command = CreateCommand(out var factory);
+
+        var created = await command.CreateTagAsync(100, 1, "hello", " hello @everyone ");
+        var duplicate = await command.CreateTagAsync(100, 1, "hello", "again");
+        var reserved = await command.CreateTagAsync(100, 1, "Ping", "content");
+        var sensitive = await command.CreateTagAsync(100, 1, "bad/name", "content");
+        var emptyContent = await command.CreateTagAsync(100, 1, "empty", "@everyone");
+
+        Assert.True(created.IsSuccess);
+        Assert.True(duplicate.IsFailure);
+        Assert.Equal("Tag name already exists on this server.", duplicate.Error);
+        Assert.True(reserved.IsFailure);
+        Assert.True(sensitive.IsFailure);
+        Assert.True(emptyContent.IsFailure);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var tag = Assert.Single(db.Tags);
+        Assert.Equal("hello", tag.Command);
+        Assert.Equal(" hello  ", tag.Content);
+    }
+
+    [Fact]
+    public async Task FindListSearchRandomAndIncrement_ReturnMappedTags()
+    {
+        var command = CreateCommand(out var factory);
+        await SeedTagsAsync(factory);
+
+        var found = await command.FindTagAsync(1, "alpha");
+        var missing = await command.FindTagAsync(1, "missing");
+        var tags = await command.FindTagsAsync(1, top: false, Maybe<long>.None);
+        var authorTags = await command.FindTagsAsync(1, top: false, 200);
+        var autocomplete = await command.FindTagNamesForAutocompleteAsync(1, Maybe<long>.None, "a");
+        var random = await command.GetRandomTagAsync(100, 1);
+        await command.IncrementTagUsageAsync(found.Value.TagId);
+
+        Assert.True(found.IsSuccess);
+        Assert.Equal("alpha", found.Value.Command);
+        Assert.True(missing.IsFailure);
+        Assert.True(tags.IsSuccess);
+        Assert.Equal(2, tags.Value.Count);
+        Assert.True(authorTags.IsSuccess);
+        Assert.Equal(200, Assert.Single(authorTags.Value).UserId);
+        Assert.Contains("alpha", autocomplete);
+        Assert.True(random.IsSuccess);
+    }
+
+    [Fact]
+    public async Task DeleteAndUpdateTagAsync_ValidateOwnershipAndPersistChanges()
+    {
+        var command = CreateCommand(out var factory);
+        await SeedTagsAsync(factory);
+
+        var missingDelete = await command.DeleteTagAsync(100, 1, "missing", hasMessageEditPerms: true);
+        var notOwnerDelete = await command.DeleteTagAsync(999, 1, "alpha", hasMessageEditPerms: true);
+        var missingUpdate = await command.UpdateTagAsync(100, 1, "missing", "content", hasMessageEditPerms: true);
+        var emptyUpdate = await command.UpdateTagAsync(100, 1, "alpha", "@here", hasMessageEditPerms: true);
+        var notOwnerUpdate = await command.UpdateTagAsync(999, 1, "alpha", "content", hasMessageEditPerms: true);
+        var updated = await command.UpdateTagAsync(100, 1, "alpha", "updated", hasMessageEditPerms: true);
+        var deleted = await command.DeleteTagAsync(100, 1, "alpha", hasMessageEditPerms: true);
+        var afterDelete = await command.FindTagAsync(1, "alpha");
+
+        Assert.True(missingDelete.IsFailure);
+        Assert.True(notOwnerDelete.IsFailure);
+        Assert.True(missingUpdate.IsFailure);
+        Assert.True(emptyUpdate.IsFailure);
+        Assert.True(notOwnerUpdate.IsFailure);
+        Assert.True(updated.IsSuccess);
+        Assert.True(deleted.IsSuccess);
+        Assert.True(afterDelete.IsFailure);
+    }
+
+    [Fact]
+    public async Task RenameTagAsync_ValidatesOwnershipAndPersistsChanges()
+    {
+        var command = CreateCommand(out var factory);
+        await SeedTagsAsync(factory);
+
+        var existingName = await command.RenameTagAsync(100, 1, "alpha", "beta", hasMessageEditPerms: true);
+        var reserved = await command.RenameTagAsync(100, 1, "alpha", "Ping", hasMessageEditPerms: true);
+        var empty = await command.RenameTagAsync(100, 1, "alpha", "", hasMessageEditPerms: true);
+        var missing = await command.RenameTagAsync(100, 1, "missing", "gamma", hasMessageEditPerms: true);
+        var notOwner = await command.RenameTagAsync(999, 1, "alpha", "gamma", hasMessageEditPerms: true);
+        var renamed = await command.RenameTagAsync(100, 1, "alpha", "gamma", hasMessageEditPerms: true);
+        var oldName = await command.FindTagAsync(1, "alpha");
+        var newName = await command.FindTagAsync(1, "gamma");
+
+        Assert.True(existingName.IsFailure);
+        Assert.True(reserved.IsFailure);
+        Assert.True(empty.IsFailure);
+        Assert.True(missing.IsFailure);
+        Assert.True(notOwner.IsFailure);
+        Assert.True(renamed.IsSuccess);
+        Assert.True(oldName.IsFailure);
+        Assert.True(newName.IsSuccess);
+    }
+
+    private static TagCommands CreateCommand(out InfrastructureTestDbFactory factory)
+    {
+        factory = new InfrastructureTestDbFactory();
+        return new TagCommands(new TagService(new MemoryCache(new MemoryCacheOptions()), factory));
+    }
+
+    private static async Task SeedTagsAsync(InfrastructureTestDbFactory factory)
+    {
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Tags.AddRange(
+            new Tag
+            {
+                GuildId = 1,
+                UserId = 100,
+                Command = "alpha",
+                Content = "first content",
+                Count = 1,
+                Date = DateTime.UtcNow
+            },
+            new Tag
+            {
+                GuildId = 1,
+                UserId = 200,
+                Command = "beta",
+                Content = "second content",
+                Count = 2,
+                Date = DateTime.UtcNow
+            });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Extensions/InfrastructureExtensionsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Extensions/InfrastructureExtensionsTests.cs
@@ -1,0 +1,216 @@
+using dotBento.Infrastructure.Extensions;
+using dotBento.Infrastructure.Models.LastFm.Common;
+using dotBento.Infrastructure.Models.LastFm.RecentTracks;
+using dotBento.Infrastructure.Models.LastFm.TopAlbums;
+using dotBento.Infrastructure.Models.LastFm.TopArtists;
+using dotBento.Infrastructure.Models.LastFm.TopTracks;
+using dotBento.Infrastructure.Models.LastFm.UserInfo;
+using EfProfile = dotBento.EntityFramework.Entities.Profile;
+using EfReminder = dotBento.EntityFramework.Entities.Reminder;
+using EfTag = dotBento.EntityFramework.Entities.Tag;
+
+namespace dotBento.Infrastructure.Tests.Extensions;
+
+public class InfrastructureExtensionsTests
+{
+    private static List<Image> Images() =>
+    [
+        new Image("small.png", "small"),
+        new Image("large.png", "large")
+    ];
+
+    [Fact]
+    public void ToBentoLastFmRecentTrack_MapsNowPlayingTrack()
+    {
+        var track = new RecentTrack(
+            new RecentTrackAttribute("true"),
+            null,
+            null,
+            new SmallArtistRecentTrack(null, null, "Artist"),
+            Images(),
+            null,
+            new Uri("https://last.fm/track"),
+            "Track",
+            new SmallAlbum(null, "Album"));
+
+        var result = track.ToBentoLastFmRecentTrack();
+
+        Assert.True(result.NowPlaying);
+        Assert.Equal("Artist", result.Artist);
+        Assert.Equal("Track", result.Track);
+        Assert.Equal("Album", result.Album);
+        Assert.Equal("large.png", result.Image);
+        Assert.Equal("https://last.fm/track", result.Url);
+        Assert.Null(result.Date);
+    }
+
+    [Fact]
+    public void ToBentoLastFmRecentTrack_MapsHistoricalTrackDate()
+    {
+        var track = new RecentTrack(
+            null,
+            null,
+            null,
+            new SmallArtistRecentTrack(null, null, "Artist"),
+            Images(),
+            new Date("60", "date"),
+            new Uri("https://last.fm/track"),
+            "Track",
+            new SmallAlbum(null, "Album"));
+
+        var result = track.ToBentoLastFmRecentTrack();
+
+        Assert.False(result.NowPlaying);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(60), result.Date);
+    }
+
+    [Fact]
+    public void ToBentoLastFmRecentTracksWithTotalTracks_MapsOnlyFirstTwoTracksAndTotal()
+    {
+        RecentTrack Track(string name) => new(
+            null,
+            null,
+            null,
+            new SmallArtistRecentTrack(null, null, "Artist"),
+            Images(),
+            new Date("60", "date"),
+            new Uri($"https://last.fm/{name}"),
+            name,
+            new SmallAlbum(null, "Album"));
+        var tracks = new RecentTracksWithUserAttributes(
+            new Attributes("1", "3", "user", "10", "1"),
+            [Track("one"), Track("two"), Track("three")]);
+
+        var result = tracks.ToBentoLastFmRecentTracksWithTotalTracks();
+
+        Assert.Equal(3, result.TotalTracks);
+        Assert.Equal(["one", "two"], result.RecentTracks.Select(t => t.Track));
+    }
+
+    [Fact]
+    public void TopLastFmMappers_MapSharedFields()
+    {
+        var album = new TopAlbum(
+            null,
+            "Album",
+            Images(),
+            new SmallArtist(null, null, "Artist"),
+            new Uri("https://last.fm/album"),
+            new RankAttribute("2"),
+            "42");
+        var track = new TopTrack(
+            new TopTrackStreamable(null, null),
+            null,
+            "Track",
+            Images(),
+            new SmallArtist(null, null, "Artist"),
+            new Uri("https://last.fm/track"),
+            "123",
+            new RankAttribute("3"),
+            "43");
+        var artist = new TopArtist(
+            "0",
+            null,
+            "Artist",
+            Images(),
+            new Uri("https://last.fm/artist"),
+            new RankAttribute("4"),
+            "44");
+
+        var mappedAlbum = album.ToBentoLastFmTopAlbum();
+        var mappedTrack = track.ToBentoLastFmTopTrack();
+        var mappedArtist = artist.ToBentoLastFmTopArtist();
+
+        Assert.Equal(("Album", "Artist", "large.png", "https://last.fm/album", 42, 2),
+            (mappedAlbum.Name, mappedAlbum.Artist, mappedAlbum.ImageUrl, mappedAlbum.Url, mappedAlbum.PlayCount, mappedAlbum.Rank));
+        Assert.Equal(("Track", "Artist", "large.png", "https://last.fm/track", 43, 3),
+            (mappedTrack.Name, mappedTrack.Artist, mappedTrack.ImageUrl, mappedTrack.Url, mappedTrack.PlayCount, mappedTrack.Rank));
+        Assert.Equal(("Artist", "large.png", "https://last.fm/artist", 44, 4),
+            (mappedArtist.Name, mappedArtist.ImageUrl, mappedArtist.Url, mappedArtist.PlayCount, mappedArtist.Rank));
+    }
+
+    [Fact]
+    public void ToBentoLastFmUserInfo_MapsAllFields()
+    {
+        var userInfo = new UserInfo(
+            "Name",
+            "0",
+            "0",
+            "Real",
+            "0",
+            "100",
+            "20",
+            "0",
+            "30",
+            "10",
+            Images(),
+            new UserInfoRegistered("60", 60),
+            "DK",
+            "n",
+            new Uri("https://last.fm/user"),
+            "user");
+
+        var result = userInfo.ToBentoLastFmUserInfo();
+
+        Assert.Equal("Name", result.Name);
+        Assert.Equal("large.png", result.ImageUrl);
+        Assert.Equal("https://last.fm/user", result.Url);
+        Assert.Equal("DK", result.Country);
+        Assert.Equal(100, result.PlayCount);
+        Assert.Equal(20, result.ArtistCount);
+        Assert.Equal(10, result.AlbumCount);
+        Assert.Equal(30, result.TrackCount);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(60), result.RegisteredAt);
+    }
+
+    [Fact]
+    public void EntityMappers_MapProfileReminderAndTag()
+    {
+        var profile = new EfProfile
+        {
+            UserId = 1,
+            LastfmBoard = true,
+            XpBoard = false,
+            BackgroundUrl = "https://image",
+            BackgroundColourOpacity = 80,
+            BackgroundColour = "#112233",
+            Description = "hello",
+            Timezone = "Europe/Copenhagen",
+            Birthday = "2000-01-01",
+            XpBar2Colour = "#445566"
+        };
+        var reminderDate = new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        var reminder = new EfReminder
+        {
+            Id = 5,
+            UserId = 1,
+            Reminder1 = "remember",
+            Date = reminderDate
+        };
+        var tagDate = DateTime.UtcNow;
+        var tag = new EfTag
+        {
+            TagId = 7,
+            UserId = 1,
+            GuildId = 2,
+            Date = tagDate,
+            Command = "hello",
+            Content = "world",
+            Count = 3
+        };
+
+        var mappedProfile = profile.Map();
+        var mappedReminder = reminder.Map();
+        var mappedTag = tag.ToBentoTag();
+
+        Assert.Equal(1, mappedProfile.UserId);
+        Assert.True(mappedProfile.LastfmBoard);
+        Assert.False(mappedProfile.XpBoard);
+        Assert.Equal("https://image", mappedProfile.BackgroundUrl);
+        Assert.Equal("#445566", mappedProfile.XpBar2Colour);
+        Assert.Equal((5, 1L, "remember", reminderDate),
+            (mappedReminder.Id, mappedReminder.UserId, mappedReminder.Content, mappedReminder.Date));
+        Assert.Equal((7L, 1L, 2L, tagDate, "hello", "world", 3),
+            (mappedTag.TagId, mappedTag.UserId, mappedTag.GuildId, mappedTag.Date, mappedTag.Command, mappedTag.Content, mappedTag.Count));
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/InfrastructureTestDbFactory.cs
+++ b/tests/dotBento.Infrastructure.Tests/InfrastructureTestDbFactory.cs
@@ -1,0 +1,27 @@
+using dotBento.EntityFramework.Context;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Configuration;
+
+namespace dotBento.Infrastructure.Tests;
+
+internal sealed class InfrastructureTestDbFactory : IDbContextFactory<BotDbContext>
+{
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly InMemoryDatabaseRoot _root = new();
+    private readonly IConfiguration _configuration = new ConfigurationBuilder().Build();
+
+    public BotDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<BotDbContext>()
+            .UseInMemoryDatabase(_dbName, _root)
+            .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
+            .Options;
+
+        return new BotDbContext(_configuration, options);
+    }
+
+    public Task<BotDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(CreateDbContext());
+}

--- a/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
@@ -1,5 +1,20 @@
 using System.Reflection;
+using System.Net;
+using CSharpFunctionalExtensions;
+using dotBento.Domain.Entities;
+using dotBento.EntityFramework.Entities;
 using dotBento.Infrastructure.Commands;
+using dotBento.Infrastructure.Services;
+using dotBento.Infrastructure.Services.Api;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using DomainProfile = dotBento.Domain.Entities.Profile;
+using EfGuild = dotBento.EntityFramework.Entities.Guild;
+using EfGuildMember = dotBento.EntityFramework.Entities.GuildMember;
+using EfUser = dotBento.EntityFramework.Entities.User;
 
 namespace dotBento.Infrastructure.Tests;
 
@@ -12,6 +27,14 @@ public class ProfileCommandsTests
         Assert.NotNull(method);
         var result = method.Invoke(null, args);
         return result is null ? default : (T)result;
+    }
+
+    private static async Task<T> InvokePrivateInstanceAsync<T>(object instance, string methodName, params object?[]? args)
+    {
+        var method = instance.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var task = (Task<T>)method.Invoke(instance, args)!;
+        return await task;
     }
 
     [Theory]
@@ -96,5 +119,172 @@ public class ProfileCommandsTests
     {
         var result = InvokePrivateStatic<string>(typeof(ProfileCommands), "LastFmTextPxSize", length);
         Assert.Equal(expectedPx, result);
+    }
+
+    [Fact]
+    public async Task GetUserXpBoardHtml_ReturnsBoardWhenUserGuildAndMemberExist()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new EfUser { UserId = 10, Username = "User", Discriminator = "0001", Level = 3, Xp = 50 });
+            db.Guilds.Add(new EfGuild
+            {
+                GuildId = 100,
+                GuildName = "Guild",
+                Prefix = "!",
+                Icon = "guild.png",
+                Leaderboard = true,
+                Media = false,
+                Tiktok = false
+            });
+            db.GuildMembers.Add(new EfGuildMember { GuildId = 100, UserId = 10, Level = 2, Xp = 25 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var command = CreateCommand(factory);
+        var profile = DefaultProfile(10);
+
+        var result = await InvokePrivateInstanceAsync<Maybe<string>>(
+            command,
+            "GetUserXpBoardHtml",
+            profile,
+            100L,
+            "bot.png");
+
+        Assert.True(result.HasValue);
+        Assert.Contains("guild.png", result.Value);
+        Assert.Contains("Level 2", result.Value);
+        Assert.Contains("bot.png", result.Value);
+        Assert.Contains("Level 3", result.Value);
+    }
+
+    [Fact]
+    public async Task GetUserEmotes_AddsSupportDeveloperAndPatreonEmotes()
+    {
+        const long developerUserId = 232584569289703424;
+        const long supportGuildId = 714496317522444352;
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new EfUser { UserId = developerUserId, Username = "Dev", Discriminator = "0001", Level = 1, Xp = 0 });
+            db.Guilds.Add(new EfGuild
+            {
+                GuildId = supportGuildId,
+                GuildName = "Support",
+                Prefix = "!",
+                Leaderboard = true,
+                Media = false,
+                Tiktok = false
+            });
+            db.GuildMembers.Add(new EfGuildMember { GuildId = supportGuildId, UserId = developerUserId, Level = 1, Xp = 0 });
+            db.Patreons.Add(new Patreon
+            {
+                UserId = developerUserId,
+                Name = "Patron",
+                Avatar = "avatar.png",
+                Sponsor = true,
+                EmoteSlot1 = "one.png",
+                EmoteSlot2 = "two.png",
+                EmoteSlot3 = "three.png",
+                EmoteSlot4 = "four.png"
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var command = CreateCommand(factory);
+
+        var emotes = await InvokePrivateInstanceAsync<string[]>(command, "GetUserEmotes", developerUserId);
+
+        Assert.Contains("🍱", emotes);
+        Assert.Contains("👨‍💻", emotes);
+        Assert.Contains("""<img src="one.png" width="24" height="24">""", emotes);
+        Assert.Contains("""<img src="two.png" width="24" height="24">""", emotes);
+        Assert.Contains("""<img src="three.png" width="24" height="24">""", emotes);
+        Assert.Contains("""<img src="four.png" width="24" height="24">""", emotes);
+    }
+
+    [Fact]
+    public async Task GetLastFmNowPlayingHtml_ReturnsBoardWhenRecentTrackExists()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new EfUser { UserId = 10, Username = "User", Discriminator = "0001", Level = 1, Xp = 0 });
+            db.Lastfms.Add(new Lastfm { UserId = 10, Lastfm1 = "listener" });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var command = CreateCommand(factory, CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("""
+            {
+              "recenttracks": {
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "1", "perPage": "2" },
+                "track": [
+                  {
+                    "@attr": { "nowplaying": "true" },
+                    "mbid": null,
+                    "loved": null,
+                    "artist": { "url": null, "mbid": null, "#text": "Artist" },
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "date": null,
+                    "url": "https://last.fm/now",
+                    "name": "Track",
+                    "album": { "mbid": null, "#text": "Album" }
+                  }
+                ]
+              }
+            }
+            """)
+        }));
+        var profile = DefaultProfile(10);
+
+        var result = await InvokePrivateInstanceAsync<Maybe<LastFmHtmlBoardResult>>(
+            command,
+            "GetLastFmNowPlayingHtml",
+            profile,
+            "api-key");
+
+        Assert.True(result.HasValue);
+        Assert.Contains("Track", result.Value.LastFmHtml);
+        Assert.Contains("Artist", result.Value.LastFmHtml);
+        Assert.Contains("large.png", result.Value.LastFmHtml);
+        Assert.Equal(5, result.Value.LastFmTrackLength);
+        Assert.Equal(6, result.Value.LastFmArtistLength);
+    }
+
+    private static DomainProfile DefaultProfile(long userId) =>
+        InvokePrivateStatic<DomainProfile>(typeof(ProfileCommands), "DefaultProfile", userId)!;
+
+    private static ProfileCommands CreateCommand(
+        InfrastructureTestDbFactory factory,
+        HttpClient? lastFmClient = null,
+        HttpClient? sushiiClient = null)
+    {
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var distributedCache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        return new ProfileCommands(
+            new ProfileService(distributedCache, factory),
+            new SushiiImageServerService(sushiiClient ?? CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.OK })),
+            new LastFmCommands(
+                new LastFmApiService(lastFmClient ?? CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.OK })),
+                new SushiiImageServerService(sushiiClient ?? CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.OK }))),
+            new LastFmService(factory),
+            new UserService(memoryCache, factory),
+            new GuildService(factory, memoryCache),
+            new BentoService(memoryCache, factory));
+    }
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        return new HttpClient(mockHandler.Object);
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
@@ -122,6 +122,76 @@ public class ProfileCommandsTests
     }
 
     [Fact]
+    public void MergeWithDefaults_FillsMissingProfileSettings()
+    {
+        var partial = new DomainProfile(
+            UserId: 10,
+            LastfmBoard: null,
+            XpBoard: null,
+            BackgroundUrl: null,
+            BackgroundColourOpacity: null,
+            BackgroundColour: null,
+            DescriptionColourOpacity: null,
+            DescriptionColour: null,
+            OverlayOpacity: null,
+            OverlayColour: null,
+            UsernameColour: null,
+            DiscriminatorColour: null,
+            SidebarItemServerColour: null,
+            SidebarItemGlobalColour: null,
+            SidebarItemBentoColour: null,
+            SidebarItemTimezoneColour: null,
+            SidebarValueServerColour: null,
+            SidebarValueGlobalColour: null,
+            SidebarValueBentoColour: null,
+            SidebarOpacity: null,
+            SidebarColour: null,
+            SidebarBlur: null,
+            FmDivBgOpacity: null,
+            FmDivBgColour: null,
+            FmSongTextOpacity: null,
+            FmSongTextColour: null,
+            FmArtistTextOpacity: null,
+            FmArtistTextColour: null,
+            XpDivBgOpacity: null,
+            XpDivBgColour: null,
+            XpTextOpacity: null,
+            XpTextColour: null,
+            XpText2Opacity: null,
+            XpText2Colour: null,
+            XpDoneServerColour1Opacity: null,
+            XpDoneServerColour1: null,
+            XpDoneServerColour2Opacity: null,
+            XpDoneServerColour2: null,
+            XpDoneServerColour3Opacity: null,
+            XpDoneServerColour3: null,
+            XpDoneGlobalColour1Opacity: null,
+            XpDoneGlobalColour1: null,
+            XpDoneGlobalColour2Opacity: null,
+            XpDoneGlobalColour2: null,
+            XpDoneGlobalColour3Opacity: null,
+            XpDoneGlobalColour3: null,
+            Description: "keep me",
+            Timezone: null,
+            Birthday: null,
+            XpBarOpacity: null,
+            XpBarColour: null,
+            XpBar2Opacity: null,
+            XpBar2Colour: null);
+
+        var result = InvokePrivateStatic<DomainProfile>(typeof(ProfileCommands), "MergeWithDefaults", partial)!;
+
+        Assert.False(result.LastfmBoard);
+        Assert.True(result.XpBoard);
+        Assert.Equal("#1F2937", result.BackgroundColour);
+        Assert.Equal(20, result.OverlayOpacity);
+        Assert.Equal("#ffffff", result.UsernameColour);
+        Assert.Equal("#111827", result.FmDivBgColour);
+        Assert.Equal("#374151", result.XpBarColour);
+        Assert.Equal("keep me", result.Description);
+    }
+
+    [Fact]
     public async Task GetUserXpBoardHtml_ReturnsBoardWhenUserGuildAndMemberExist()
     {
         var factory = new InfrastructureTestDbFactory();
@@ -250,6 +320,58 @@ public class ProfileCommandsTests
         Assert.Contains("large.png", result.Value.LastFmHtml);
         Assert.Equal(5, result.Value.LastFmTrackLength);
         Assert.Equal(6, result.Value.LastFmArtistLength);
+    }
+
+    [Fact]
+    public async Task GenerateProfileHtml_RendersProfileSidebarAndLayoutData()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new EfUser { UserId = 10, Username = "User", Discriminator = "0001", Level = 4, Xp = 350 });
+            db.Guilds.Add(new EfGuild
+            {
+                GuildId = 100,
+                GuildName = "Guild",
+                Prefix = "!",
+                Icon = "guild.png",
+                MemberCount = 1234,
+                Leaderboard = true,
+                Media = false,
+                Tiktok = false
+            });
+            db.GuildMembers.Add(new EfGuildMember { GuildId = 100, UserId = 10, Level = 3, Xp = 250 });
+            db.Bentos.Add(new Bento { UserId = 10, Bento1 = 42, BentoDate = DateTime.UtcNow });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var command = CreateCommand(factory);
+        var profile = DefaultProfile(10) with
+        {
+            XpBoard = false,
+            BackgroundUrl = "https://cdn.example/background.png",
+            Description = "Custom description",
+            Birthday = "February 18"
+        };
+
+        var html = await command.GenerateProfileHtml(
+            profile,
+            "lastfm-api-key",
+            100,
+            new ProfileDiscordUser(null, "0007", "DisplayName", "Nickname"),
+            1234,
+            "bot.png");
+
+        Assert.Contains("https://cdn.example/background.png", html);
+        Assert.Contains("Custom description", html);
+        Assert.Contains("https://cdn.discordapp.com/embed/avatars/2.png", html);
+        Assert.Contains("DisplayName", html);
+        Assert.Contains("Nickname", html);
+        Assert.Contains("Rank 1", html);
+        Assert.Contains("Of 1234 Users", html);
+        Assert.Contains("42 🍱", html);
+        Assert.Contains("Feb 18 🎂", html);
+        Assert.Contains("height: 365px", html);
+        Assert.Contains("opacity: 0", html);
     }
 
     private static DomainProfile DefaultProfile(long userId) =>

--- a/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/ProfileCommandsTests.cs
@@ -48,6 +48,8 @@ public class ProfileCommandsTests
     [InlineData("7/2", "Jul 2 🎂")]            // M/d (new syntax)
     [InlineData("7 february", "Feb 7 🎂")]     // text, lowercase month
     [InlineData("February 18", "Feb 18 🎂")]   // text, Month d
+    [InlineData("31/12", "Dec 31 🎂")]         // day-first numeric
+    [InlineData("February 18, 2000", "Feb 18 🎂")] // en-US fallback with comma
     [InlineData("20 April 2000", "Apr 20 🎂")] // text with year
     [InlineData("25 Nov", "Nov 25 🎂")]        // short month
     [InlineData("  February   1  ", "Feb 1 🎂")] // extra spaces
@@ -374,8 +376,112 @@ public class ProfileCommandsTests
         Assert.Contains("opacity: 0", html);
     }
 
+    [Fact]
+    public async Task GenerateProfileHtml_RendersXpOnlyLayoutAndTimezone()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await SeedProfileRenderDataAsync(factory);
+        var command = CreateCommand(factory);
+        var profile = DefaultProfile(10) with
+        {
+            XpBoard = true,
+            LastfmBoard = false,
+            Timezone = "UTC"
+        };
+
+        var html = await command.GenerateProfileHtml(
+            profile,
+            "lastfm-api-key",
+            100,
+            new ProfileDiscordUser("avatar.png", "0007", "DisplayName", null),
+            1234,
+            "bot.png");
+
+        Assert.Contains("height: 310px", html);
+        Assert.Contains("padding-top: 88px", html);
+        Assert.Contains("Level 3", html);
+        Assert.Contains("Level 4", html);
+        Assert.Contains("#0007", html);
+    }
+
+    [Fact]
+    public async Task GenerateProfileHtml_RendersLastFmOnlyLayout()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await SeedProfileRenderDataAsync(factory, includeLastFm: true);
+        var command = CreateCommand(factory, CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("""
+            {
+              "recenttracks": {
+                "@attr": { "page": "1", "totalPages": "1", "user": "listener", "total": "1", "perPage": "1" },
+                "track": [
+                  {
+                    "@attr": { "nowplaying": "true" },
+                    "mbid": null,
+                    "loved": null,
+                    "artist": { "url": null, "mbid": null, "#text": "Artist" },
+                    "image": [{ "#text": "small.png", "size": "small" }, { "#text": "large.png", "size": "large" }],
+                    "date": null,
+                    "url": "https://last.fm/now",
+                    "name": "Track",
+                    "album": { "mbid": null, "#text": "Album" }
+                  }
+                ]
+              }
+            }
+            """)
+        }));
+        var profile = DefaultProfile(10) with
+        {
+            XpBoard = false,
+            LastfmBoard = true
+        };
+
+        var html = await command.GenerateProfileHtml(
+            profile,
+            "lastfm-api-key",
+            100,
+            new ProfileDiscordUser("avatar.png", "0007", "DisplayName", null),
+            1234,
+            "bot.png");
+
+        Assert.Contains("height: 310px", html);
+        Assert.Contains("padding-top: 88px", html);
+        Assert.Contains("Track", html);
+        Assert.Contains("Artist", html);
+    }
+
     private static DomainProfile DefaultProfile(long userId) =>
         InvokePrivateStatic<DomainProfile>(typeof(ProfileCommands), "DefaultProfile", userId)!;
+
+    private static async Task SeedProfileRenderDataAsync(
+        InfrastructureTestDbFactory factory,
+        bool includeLastFm = false)
+    {
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.Users.Add(new EfUser { UserId = 10, Username = "User", Discriminator = "0001", Level = 4, Xp = 350 });
+        db.Guilds.Add(new EfGuild
+        {
+            GuildId = 100,
+            GuildName = "Guild",
+            Prefix = "!",
+            Icon = "guild.png",
+            MemberCount = 1234,
+            Leaderboard = true,
+            Media = false,
+            Tiktok = false
+        });
+        db.GuildMembers.Add(new EfGuildMember { GuildId = 100, UserId = 10, Level = 3, Xp = 250 });
+        db.Bentos.Add(new Bento { UserId = 10, Bento1 = 42, BentoDate = DateTime.UtcNow });
+        if (includeLastFm)
+        {
+            db.Lastfms.Add(new Lastfm { UserId = 10, Lastfm1 = "listener" });
+        }
+
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
 
     private static ProfileCommands CreateCommand(
         InfrastructureTestDbFactory factory,

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/BentoMediaServerServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/BentoMediaServerServiceTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using dotBento.Infrastructure.Services.Api;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Services.Api;
+
+public sealed class BentoMediaServerServiceTests
+{
+    [Fact]
+    public async Task ResolveAsync_ReturnsResponseAndSendsApiKey()
+    {
+        HttpRequestMessage? request = null;
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("""
+            {
+              "platform": "youtube",
+              "source_url": "https://source.example/watch",
+              "posted_at": null,
+              "author": {
+                "username": "author",
+                "display_name": "Author"
+              },
+              "content": {
+                "caption": "caption",
+                "attachments": [
+                  {
+                    "type": "video",
+                    "url": "https://cdn.example/video.mp4",
+                    "content_type": "video/mp4",
+                    "proxy": true
+                  }
+                ]
+              }
+            }
+            """)
+        }, message => request = message);
+        var service = new BentoMediaServerService(httpClient);
+
+        var result = await service.ResolveAsync("https://media.example", "https://source.example/watch", "secret");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("https://cdn.example/video.mp4", Assert.Single(result.Value.Content.Attachments).Url);
+        Assert.Equal("secret", request!.Headers.GetValues("X-API-Key").Single());
+        Assert.Equal("https://media.example/resolve", request.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ReturnsFailureForHttpErrorNullPayloadAndException()
+    {
+        using var errorClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.BadGateway,
+            Content = new StringContent("upstream down")
+        });
+        using var nullClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("null")
+        });
+        using var throwingClient = CreateHttpClient(new HttpRequestException("offline"));
+
+        var httpError = await new BentoMediaServerService(errorClient).ResolveAsync("https://media.example", "url");
+        var nullPayload = await new BentoMediaServerService(nullClient).ResolveAsync("https://media.example", "url");
+        var exception = await new BentoMediaServerService(throwingClient).ResolveAsync("https://media.example", "url");
+
+        Assert.True(httpError.IsFailure);
+        Assert.Contains("502", httpError.Error);
+        Assert.True(nullPayload.IsFailure);
+        Assert.Equal("Empty response from media server", nullPayload.Error);
+        Assert.True(exception.IsFailure);
+        Assert.Contains("offline", exception.Error);
+    }
+
+    [Fact]
+    public async Task ProxyAsync_ReturnsFailureForHttpErrorAndException()
+    {
+        using var errorClient = CreateHttpClient(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound });
+        using var throwingClient = CreateHttpClient(new HttpRequestException("offline"));
+
+        var httpError = await new BentoMediaServerService(errorClient).ProxyAsync("https://media.example", "url");
+        var exception = await new BentoMediaServerService(throwingClient).ProxyAsync("https://media.example", "url");
+
+        Assert.True(httpError.IsFailure);
+        Assert.Contains("404", httpError.Error);
+        Assert.True(exception.IsFailure);
+        Assert.Contains("offline", exception.Error);
+    }
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response, Action<HttpRequestMessage>? captureRequest = null)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                captureRequest?.Invoke(request);
+                return response;
+            });
+
+        return new HttpClient(mockHandler.Object);
+    }
+
+    private static HttpClient CreateHttpClient(Exception exception)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+
+        return new HttpClient(mockHandler.Object);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/BentoMediaServerServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/BentoMediaServerServiceTests.cs
@@ -89,6 +89,48 @@ public sealed class BentoMediaServerServiceTests
         Assert.Contains("offline", exception.Error);
     }
 
+    [Fact]
+    public async Task ProxyAsync_ReturnsStreamAndSendsApiKey()
+    {
+        HttpRequestMessage? request = null;
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("proxied media")
+        }, message => request = message);
+        var service = new BentoMediaServerService(httpClient);
+
+        var result = await service.ProxyAsync(
+            "https://media.example",
+            "https://source.example/watch?v=1&name=bento",
+            "secret");
+
+        Assert.True(result.IsSuccess);
+        await using var stream = result.Value;
+        using var reader = new StreamReader(stream);
+        Assert.Equal("proxied media", await reader.ReadToEndAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("secret", request!.Headers.GetValues("X-API-Key").Single());
+        Assert.Equal(
+            "https://media.example/proxy?url=https%3A%2F%2Fsource.example%2Fwatch%3Fv%3D1%26name%3Dbento",
+            request.RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task ProxyAsync_DisposesResponseAndReturnsFailureWhenStreamCreationFails()
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new ThrowingStreamContent()
+        });
+        var service = new BentoMediaServerService(httpClient);
+
+        var result = await service.ProxyAsync("https://media.example", "url");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("stream failed", result.Error);
+    }
+
     private static HttpClient CreateHttpClient(HttpResponseMessage response, Action<HttpRequestMessage>? captureRequest = null)
     {
         var mockHandler = new Mock<HttpMessageHandler>();
@@ -119,5 +161,20 @@ public sealed class BentoMediaServerServiceTests
             .ThrowsAsync(exception);
 
         return new HttpClient(mockHandler.Object);
+    }
+
+    private sealed class ThrowingStreamContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => Task.CompletedTask;
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return true;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+            => throw new InvalidOperationException("stream failed");
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/HttpApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/HttpApiServiceTests.cs
@@ -153,6 +153,19 @@ public class HttpApiServiceTests
         Assert.Contains("offline", result.Error);
     }
 
+    [Fact]
+    public async Task DiscordApiService_ReturnsFailureWhenRequestTimesOut()
+    {
+        using var httpClient = CreateHttpClient(new TaskCanceledException("timeout"));
+        httpClient.BaseAddress = new Uri("https://discord.example/");
+        var service = new DiscordApiService(httpClient);
+
+        var result = await service.GetGuildMemberAsync(1, 2);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("Discord API request timed out", result.Error);
+    }
+
     private static HttpClient CreateHttpClient(HttpResponseMessage response)
     {
         var mockHandler = new Mock<HttpMessageHandler>();

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/HttpApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/HttpApiServiceTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using dotBento.Infrastructure.Services.Api;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Services.Api;
+
+public class HttpApiServiceTests
+{
+    [Fact]
+    public async Task UrbanDictionaryService_DeserializesDefinitions()
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("""
+            {
+              "list": [
+                {
+                  "definition": "meaning",
+                  "permalink": "https://urban.example/word",
+                  "thumbs_up": 10,
+                  "thumbs_down": 1,
+                  "author": "author",
+                  "word": "word",
+                  "written_on": "2026-01-01T00:00:00Z",
+                  "defid": 123,
+                  "example": "example"
+                }
+              ]
+            }
+            """)
+        });
+        var service = new UrbanDictionaryService(httpClient);
+
+        var result = await service.GetDefinition("word");
+
+        var definition = Assert.Single(result!.List);
+        Assert.Equal("meaning", definition.Definition);
+        Assert.Equal(10, definition.ThumbsUp);
+    }
+
+    [Fact]
+    public async Task WeatherApiService_ReturnsSuccessForValidPayload()
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("""
+            {
+              "name": "Copenhagen",
+              "id": 1,
+              "cod": 200,
+              "message": null,
+              "weather": [{ "id": 800, "main": "Clear", "description": "clear sky", "icon": "01d" }],
+              "sys": { "country": "DK", "sunrise": 1, "sunset": 2, "id": 3, "type": 4 },
+              "main": { "temp": 20, "feels_like": 19, "temp_min": 18, "temp_max": 21, "pressure": 1000, "humidity": 50 },
+              "dt": 1,
+              "timezone": 3600,
+              "visibility": 10000,
+              "base": "stations",
+              "clouds": { "all": 0 },
+              "wind": { "speed": 1.5, "deg": 180 },
+              "coord": { "lon": 12.5, "lat": 55.6 },
+              "rain": null,
+              "snow": null
+            }
+            """)
+        });
+        var service = new WeatherApiService(httpClient);
+
+        var result = await service.GetWeatherForCity("Copenhagen", "key");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Copenhagen", result.Value.Name);
+        Assert.Equal("DK", result.Value.Sys.Country);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, "Status Code 400")]
+    [InlineData(HttpStatusCode.Unauthorized, "Status Code 401")]
+    [InlineData(HttpStatusCode.NotFound, "Could not find the city")]
+    [InlineData((HttpStatusCode)429, "too many requests")]
+    [InlineData(HttpStatusCode.InternalServerError, "Internal server error")]
+    [InlineData(HttpStatusCode.ServiceUnavailable, "Service unavailable")]
+    [InlineData(HttpStatusCode.Forbidden, "Unknown error")]
+    public async Task WeatherApiService_ReturnsFriendlyFailureForErrorStatus(
+        HttpStatusCode statusCode,
+        string expectedError)
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = statusCode });
+        var service = new WeatherApiService(httpClient);
+
+        var result = await service.GetWeatherForCity("Atlantis", "key");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(expectedError, result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WeatherApiService_ReturnsFailureForNullPayload()
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("null")
+        });
+        var service = new WeatherApiService(httpClient);
+
+        var result = await service.GetWeatherForCity("Copenhagen", "key");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Could not deserialize", result.Error);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.OK, true, null)]
+    [InlineData(HttpStatusCode.NotFound, false, null)]
+    [InlineData(HttpStatusCode.Forbidden, false, "Discord API returned 403")]
+    public async Task DiscordApiService_MapsStatusCodes(
+        HttpStatusCode statusCode,
+        bool expectedValue,
+        string? expectedError)
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = statusCode });
+        httpClient.BaseAddress = new Uri("https://discord.example/");
+        var service = new DiscordApiService(httpClient);
+
+        var result = await service.GetGuildMemberAsync(1, 2);
+
+        if (expectedError is null)
+        {
+            Assert.True(result.IsSuccess);
+            Assert.Equal(expectedValue, result.Value);
+        }
+        else
+        {
+            Assert.True(result.IsFailure);
+            Assert.Equal(expectedError, result.Error);
+        }
+    }
+
+    [Fact]
+    public async Task DiscordApiService_ReturnsFailureWhenRequestThrows()
+    {
+        using var httpClient = CreateHttpClient(new HttpRequestException("offline"));
+        httpClient.BaseAddress = new Uri("https://discord.example/");
+        var service = new DiscordApiService(httpClient);
+
+        var result = await service.GetGuildMemberAsync(1, 2);
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("offline", result.Error);
+    }
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        return new HttpClient(mockHandler.Object);
+    }
+
+    private static HttpClient CreateHttpClient(Exception exception)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(exception);
+
+        return new HttpClient(mockHandler.Object);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/LastFmApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/LastFmApiServiceTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using dotBento.Infrastructure.Models.LastFm;
+using dotBento.Infrastructure.Services.Api;
+using Moq;
+using Moq.Protected;
+
+namespace dotBento.Infrastructure.Tests.Services.Api;
+
+public sealed class LastFmApiServiceTests
+{
+    [Fact]
+    public async Task LastFmApiService_DeserializesSuccessfulResponses()
+    {
+        using var httpClient = CreateHttpClient(
+            JsonResponse("""{ "recenttracks": { "track": [] } }"""),
+            JsonResponse("""{ "toptracks": { "track": [] } }"""),
+            JsonResponse("""{ "topalbums": { "album": [] } }"""),
+            JsonResponse("""{ "topartists": { "artist": [] } }"""),
+            JsonResponse("""{ "user": { "name": "listener" } }"""));
+        var service = new LastFmApiService(httpClient);
+
+        var recentTracks = await service.GetRecentTracks("listener", "api-key", 10);
+        var topTracks = await service.GetTopTracks("listener", "api-key", "7day", 10);
+        var topAlbums = await service.GetTopAlbums("listener", "api-key", "1month", 10);
+        var topArtists = await service.GetTopArtists("listener", "api-key", "12month", 10);
+        var userInfo = await service.GetUserInfo("listener", "api-key");
+
+        Assert.True(recentTracks.IsSuccess);
+        Assert.NotNull(recentTracks.Value.RecentTracks);
+        Assert.True(topTracks.IsSuccess);
+        Assert.NotNull(topTracks.Value.TopTracks);
+        Assert.True(topAlbums.IsSuccess);
+        Assert.NotNull(topAlbums.Value.TopAlbums);
+        Assert.True(topArtists.IsSuccess);
+        Assert.NotNull(topArtists.Value.TopArtists);
+        Assert.True(userInfo.IsSuccess);
+        Assert.Equal("listener", userInfo.Value.User.Name);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, "400 Bad Request")]
+    [InlineData(HttpStatusCode.Forbidden, "403 Forbidden")]
+    [InlineData(HttpStatusCode.NotFound, "404 Not Found")]
+    [InlineData(HttpStatusCode.InternalServerError, "500 Internal Server Error")]
+    [InlineData(HttpStatusCode.ServiceUnavailable, "503 Service Unavailable")]
+    [InlineData(HttpStatusCode.TooManyRequests, "429 status code")]
+    public async Task GetRecentTracks_ReturnsFriendlyFailureForErrorStatus(
+        HttpStatusCode statusCode,
+        string expectedError)
+    {
+        using var httpClient = CreateHttpClient(new HttpResponseMessage { StatusCode = statusCode });
+        var service = new LastFmApiService(httpClient);
+
+        var result = await service.GetRecentTracks("missing-user", "api-key");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains(expectedError, result.Error);
+    }
+
+    [Fact]
+    public async Task LastFmApiService_ReturnsFailureForNullPayloads()
+    {
+        using var httpClient = CreateHttpClient(
+            JsonResponse("null"),
+            JsonResponse("null"),
+            JsonResponse("null"),
+            JsonResponse("null"),
+            JsonResponse("null"));
+        var service = new LastFmApiService(httpClient);
+
+        var recentTracks = await service.GetRecentTracks("listener", "api-key");
+        var topTracks = await service.GetTopTracks("listener", "api-key", "7day");
+        var topAlbums = await service.GetTopAlbums("listener", "api-key", "7day");
+        var topArtists = await service.GetTopArtists("listener", "api-key", "7day");
+        var userInfo = await service.GetUserInfo("listener", "api-key");
+
+        Assert.True(recentTracks.IsFailure);
+        Assert.True(topTracks.IsFailure);
+        Assert.True(topAlbums.IsFailure);
+        Assert.True(topArtists.IsFailure);
+        Assert.True(userInfo.IsFailure);
+    }
+
+    [Fact]
+    public async Task GetTopTracks_SendsExpectedQueryParameters()
+    {
+        HttpRequestMessage? request = null;
+        using var httpClient = CreateHttpClient(
+            JsonResponse("""{ "toptracks": { "track": [] } }"""),
+            message => request = message);
+        var service = new LastFmApiService(httpClient);
+
+        var result = await service.GetTopTracks("listener name", "api-key", "overall", 25);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(request);
+        var query = request!.RequestUri!.Query;
+        Assert.Contains($"method={Uri.EscapeDataString(ApiMethod.TopTracks)}", query);
+        Assert.Contains("user=listener%20name", query);
+        Assert.Contains("api_key=api-key", query);
+        Assert.Contains("period=overall", query);
+        Assert.Contains("limit=25", query);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        new()
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent(json)
+        };
+
+    private static HttpClient CreateHttpClient(params HttpResponseMessage[] responses) =>
+        CreateHttpClient(responses, _ => { });
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage response, Action<HttpRequestMessage> captureRequest) =>
+        CreateHttpClient([response], captureRequest);
+
+    private static HttpClient CreateHttpClient(HttpResponseMessage[] responses, Action<HttpRequestMessage> captureRequest)
+    {
+        var queue = new Queue<HttpResponseMessage>(responses);
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) =>
+            {
+                captureRequest(request);
+                return queue.Dequeue();
+            });
+
+        return new HttpClient(mockHandler.Object);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
@@ -84,7 +84,22 @@ public sealed class StreamingApiServiceTests
             await stream.WriteAsync(new ReadOnlyMemory<byte>([1]), TestContext.Current.CancellationToken));
     }
 
+    [Fact]
+    public async Task SushiiImageServer_DisposesResponseWhenStreamCreationFails()
+    {
+        using var httpClient = CreateHttpClient(new ThrowingStreamContent());
+        var service = new SushiiImageServerService(httpClient);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.GetSushiiImage("https://image.example/render", "<html></html>", 600, 400));
+    }
+
     private static HttpClient CreateHttpClient(Stream contentStream)
+    {
+        return CreateHttpClient(new StreamContent(contentStream));
+    }
+
+    private static HttpClient CreateHttpClient(HttpContent content)
     {
         var mockHandler = new Mock<HttpMessageHandler>();
 
@@ -97,10 +112,25 @@ public sealed class StreamingApiServiceTests
             .ReturnsAsync(new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.OK,
-                Content = new StreamContent(contentStream)
+                Content = content
             });
 
         return new HttpClient(mockHandler.Object);
+    }
+
+    private sealed class ThrowingStreamContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            Task.CompletedTask;
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return true;
+        }
+
+        protected override Task<Stream> CreateContentReadStreamAsync() =>
+            throw new InvalidOperationException("stream failed");
     }
 
     private sealed class CountingStream(byte[] buffer) : MemoryStream(buffer)

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
@@ -72,6 +72,8 @@ public sealed class StreamingApiServiceTests
         Assert.Equal(1, stream.Position);
         Assert.Equal(2, stream.ReadByte());
         Assert.Equal(0, stream.Seek(0, SeekOrigin.Begin));
+        Assert.Equal(1, stream.Read(new Span<byte>(new byte[1])));
+        Assert.Equal(1, await stream.ReadAsync(new byte[1], 0, 1, TestContext.Current.CancellationToken));
         stream.Flush();
         await stream.FlushAsync(TestContext.Current.CancellationToken);
 

--- a/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/Api/StreamingApiServiceTests.cs
@@ -51,6 +51,39 @@ public sealed class StreamingApiServiceTests
         Assert.True(contentStream.IsDisposed);
     }
 
+    [Fact]
+    public async Task SushiiImageServerStream_DelegatesSyncMembersAndRejectsWrites()
+    {
+        var contentStream = new CountingStream([1, 2, 3, 4]);
+        using var httpClient = CreateHttpClient(contentStream);
+        var service = new SushiiImageServerService(httpClient);
+
+        var result = await service.GetSushiiImage("https://image.example/render", "<html></html>", 600, 400);
+
+        Assert.True(result.IsSuccess);
+        using var stream = result.Value;
+        Assert.True(stream.CanRead);
+        Assert.True(stream.CanSeek);
+        Assert.False(stream.CanWrite);
+        Assert.Equal(4, stream.Length);
+        Assert.Equal(0, stream.Position);
+
+        stream.Position = 1;
+        Assert.Equal(1, stream.Position);
+        Assert.Equal(2, stream.ReadByte());
+        Assert.Equal(0, stream.Seek(0, SeekOrigin.Begin));
+        stream.Flush();
+        await stream.FlushAsync(TestContext.Current.CancellationToken);
+
+        Assert.Throws<NotSupportedException>(() => stream.SetLength(10));
+        Assert.Throws<NotSupportedException>(() => stream.Write([1], 0, 1));
+        Assert.Throws<NotSupportedException>(() => stream.Write([1]));
+        await Assert.ThrowsAsync<NotSupportedException>(() =>
+            stream.WriteAsync([1], 0, 1, TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await stream.WriteAsync(new ReadOnlyMemory<byte>([1]), TestContext.Current.CancellationToken));
+    }
+
     private static HttpClient CreateHttpClient(Stream contentStream)
     {
         var mockHandler = new Mock<HttpMessageHandler>();

--- a/tests/dotBento.Infrastructure.Tests/Services/BentoServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/BentoServiceTests.cs
@@ -1,0 +1,135 @@
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class BentoServiceTests
+{
+    private static BentoService CreateService(
+        InfrastructureTestDbFactory factory,
+        IMemoryCache? cache = null) =>
+        new(cache ?? new MemoryCache(new MemoryCacheOptions()), factory);
+
+    [Fact]
+    public async Task FindOrCreateBentoAsync_WhenMissing_CreatesWithAmount()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = CreateService(factory);
+
+        var bento = await service.FindOrCreateBentoAsync(10, 4);
+
+        Assert.Equal(10, bento.UserId);
+        Assert.Equal(4, bento.Bento1);
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(1, await db.Bentos.CountAsync(cancellationToken: TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task FindOrCreateBentoAsync_WhenCached_ReturnsCachedValue()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        cache.Set(10L, new Bento { UserId = 10, Bento1 = 99 });
+        var service = CreateService(factory, cache);
+
+        var bento = await service.FindOrCreateBentoAsync(10, 4);
+
+        Assert.Equal(99, bento.Bento1);
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(db.Bentos);
+    }
+
+    [Fact]
+    public async Task FindBentoAsync_ReturnsNoneWhenMissing_AndCachesWhenFound()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = CreateService(factory, cache);
+
+        var missing = await service.FindBentoAsync(10);
+        Assert.True(missing.HasNoValue);
+
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Bentos.Add(new Bento { UserId = 10, Bento1 = 7, BentoDate = DateTime.UtcNow });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var found = await service.FindBentoAsync(10);
+
+        Assert.True(found.HasValue);
+        Assert.Equal(7, found.Value.Bento1);
+        Assert.True(cache.TryGetValue(10L, out Bento? cached));
+        Assert.Equal(7, cached!.Bento1);
+    }
+
+    [Fact]
+    public async Task IncrementBentoAsync_CreatesAndUpdatesExisting()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = CreateService(factory);
+
+        await service.IncrementBentoAsync(10, 3);
+        await service.IncrementBentoAsync(10, 4);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var bento = await db.Bentos.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(7, bento.Bento1);
+    }
+
+    [Fact]
+    public async Task UpsertBentoAsync_CreatesAndThenIncrements()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = CreateService(factory);
+
+        var created = await service.UpsertBentoAsync(10, 3);
+        var updated = await service.UpsertBentoAsync(10, 4);
+
+        Assert.Equal(3, created.Bento1);
+        Assert.Equal(7, updated.Bento1);
+    }
+
+    [Fact]
+    public async Task UpdateBentoDateAsync_CreatesAndUpdatesDate()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = CreateService(factory);
+        var firstDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var secondDate = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        await service.UpdateBentoDateAsync(10, firstDate);
+        await service.UpdateBentoDateAsync(10, secondDate);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var bento = await db.Bentos.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(secondDate, bento.BentoDate);
+        Assert.Equal(0, bento.Bento1);
+    }
+
+    [Fact]
+    public async Task CountsAndRank_ReturnExpectedValues()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Bentos.AddRange(
+                new Bento { UserId = 1, Bento1 = 10, BentoDate = DateTime.UtcNow },
+                new Bento { UserId = 2, Bento1 = 30, BentoDate = DateTime.UtcNow },
+                new Bento { UserId = 3, Bento1 = 20, BentoDate = DateTime.UtcNow });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var count = await service.GetTotalCountOfBentoUsersAsync();
+        var rank = await service.GetBentoRankAsync(3);
+        var missingRank = await service.GetBentoRankAsync(999);
+
+        Assert.Equal(3, count);
+        Assert.True(rank.HasValue);
+        Assert.Equal(2, rank.Value);
+        Assert.True(missingRank.HasNoValue);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/BentoServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/BentoServiceTests.cs
@@ -66,6 +66,41 @@ public class BentoServiceTests
     }
 
     [Fact]
+    public async Task FindBentoAsync_WhenCached_ReturnsCachedValue()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        cache.Set(10L, new Bento { UserId = 10, Bento1 = 42, BentoDate = DateTime.UtcNow });
+        var service = CreateService(factory, cache);
+
+        var found = await service.FindBentoAsync(10);
+
+        Assert.True(found.HasValue);
+        Assert.Equal(42, found.Value.Bento1);
+    }
+
+    [Fact]
+    public async Task CreateBentoSenderAsync_CreatesAndCachesSender()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = CreateService(factory, cache);
+        var bentoDate = new DateTime(2026, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+
+        var sender = await service.CreateBentoSenderAsync(10, bentoDate);
+
+        Assert.Equal(10, sender.UserId);
+        Assert.Equal(0, sender.Bento1);
+        Assert.Equal(bentoDate, sender.BentoDate);
+        Assert.True(cache.TryGetValue(10L, out Bento? cached));
+        Assert.Equal(bentoDate, cached!.BentoDate);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var persisted = await db.Bentos.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(bentoDate, persisted.BentoDate);
+    }
+
+    [Fact]
     public async Task IncrementBentoAsync_CreatesAndUpdatesExisting()
     {
         var factory = new InfrastructureTestDbFactory();

--- a/tests/dotBento.Infrastructure.Tests/Services/GameServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GameServiceTests.cs
@@ -38,4 +38,14 @@ public class GameServiceTests
         var value = typeof(EntityFramework.Entities.RpsGame).GetProperty(propertyName)!.GetValue(game);
         Assert.Equal(2, value);
     }
+
+    [Fact]
+    public async Task UpdateRpsStatsAsync_ThrowsForInvalidChoice()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = new GameService(factory);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            service.UpdateRpsStatsAsync(10, (RpsGameChoice)999, RpsGameResult.Draw));
+    }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/GameServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GameServiceTests.cs
@@ -1,0 +1,41 @@
+using dotBento.Domain.Enums.Games;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class GameServiceTests
+{
+    public static IEnumerable<object[]> RpsCases() =>
+    new List<object[]>
+    {
+        new object[] { RpsGameChoice.Rock, RpsGameResult.Win, nameof(EntityFramework.Entities.RpsGame.RockWins) },
+        new object[] { RpsGameChoice.Rock, RpsGameResult.Loss, nameof(EntityFramework.Entities.RpsGame.RockLosses) },
+        new object[] { RpsGameChoice.Rock, RpsGameResult.Draw, nameof(EntityFramework.Entities.RpsGame.RockTies) },
+        new object[] { RpsGameChoice.Paper, RpsGameResult.Win, nameof(EntityFramework.Entities.RpsGame.PaperWins) },
+        new object[] { RpsGameChoice.Paper, RpsGameResult.Loss, nameof(EntityFramework.Entities.RpsGame.PaperLosses) },
+        new object[] { RpsGameChoice.Paper, RpsGameResult.Draw, nameof(EntityFramework.Entities.RpsGame.PaperTies) },
+        new object[] { RpsGameChoice.Scissors, RpsGameResult.Win, nameof(EntityFramework.Entities.RpsGame.ScissorWins) },
+        new object[] { RpsGameChoice.Scissors, RpsGameResult.Loss, nameof(EntityFramework.Entities.RpsGame.ScissorsLosses) },
+        new object[] { RpsGameChoice.Scissors, RpsGameResult.Draw, nameof(EntityFramework.Entities.RpsGame.ScissorsTies) }
+    };
+
+    [Theory]
+    [MemberData(nameof(RpsCases))]
+    public async Task UpdateRpsStatsAsync_IncrementsExpectedColumn(
+        RpsGameChoice choice,
+        RpsGameResult result,
+        string propertyName)
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = new GameService(factory);
+
+        await service.UpdateRpsStatsAsync(10, choice, result);
+        await service.UpdateRpsStatsAsync(10, choice, result);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var game = await db.RpsGames.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var value = typeof(EntityFramework.Entities.RpsGame).GetProperty(propertyName)!.GetValue(game);
+        Assert.Equal(2, value);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
@@ -214,4 +214,67 @@ public class GuildServiceTests
         Assert.Equal("Updated", guild.GuildName);
         Assert.Equal("https://cdn.example.com/icon.png", guild.Icon);
     }
+
+    [Fact]
+    public async Task SyncGuildFromDiscordAsync_ReturnsFalseWhenFieldsMatch()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            var guild = Guild(100);
+            guild.Icon = "https://cdn.example.com/icon.png";
+            db.Guilds.Add(guild);
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var discordGuild = new Mock<IGuild>();
+        discordGuild.SetupGet(g => g.Name).Returns("Guild100");
+        discordGuild.SetupGet(g => g.IconUrl).Returns("https://cdn.example.com/icon.png");
+        var service = CreateService(factory);
+
+        var changed = await service.SyncGuildFromDiscordAsync(Guild(100), discordGuild.Object);
+
+        Assert.False(changed);
+    }
+
+    [Fact]
+    public async Task SyncGuildMemberFromDiscordAsync_UpdatesAvatarAndHandlesNoChangeOrMissing()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.Add(User(10));
+            db.GuildMembers.Add(new GuildMember
+            {
+                GuildMemberId = 1,
+                GuildId = 100,
+                UserId = 10,
+                Level = 1,
+                Xp = 0,
+                AvatarUrl = "old.png"
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var discordGuildUser = new Mock<IGuildUser>();
+        discordGuildUser
+            .Setup(x => x.GetGuildAvatarUrl(ImageFormat.Auto, 512))
+            .Returns("new.png");
+        var service = CreateService(factory);
+
+        var changed = await service.SyncGuildMemberFromDiscordAsync(
+            new GuildMember { GuildMemberId = 1 },
+            discordGuildUser.Object);
+        var unchanged = await service.SyncGuildMemberFromDiscordAsync(
+            new GuildMember { GuildMemberId = 1 },
+            discordGuildUser.Object);
+        var missing = await service.SyncGuildMemberFromDiscordAsync(
+            new GuildMember { GuildMemberId = 999 },
+            discordGuildUser.Object);
+
+        Assert.True(changed);
+        Assert.False(unchanged);
+        Assert.False(missing);
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("new.png", (await assertDb.GuildMembers.SingleAsync(cancellationToken: TestContext.Current.CancellationToken)).AvatarUrl);
+    }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
@@ -1,0 +1,217 @@
+using Discord;
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class GuildServiceTests
+{
+    private static GuildService CreateService(
+        InfrastructureTestDbFactory factory,
+        IMemoryCache? cache = null) =>
+        new(factory, cache ?? new MemoryCache(new MemoryCacheOptions()));
+
+    private static Guild Guild(long id) => new()
+    {
+        GuildId = id,
+        GuildName = $"Guild{id}",
+        Prefix = "!",
+        Leaderboard = true,
+        Media = false,
+        Tiktok = false,
+        MemberCount = 3
+    };
+
+    private static User User(long id) => new()
+    {
+        UserId = id,
+        Username = $"User{id}",
+        Discriminator = "0001",
+        Level = 1,
+        Xp = 0
+    };
+
+    [Fact]
+    public async Task GetGuildAndGuildMemberMethods_ReturnMaybeValues()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.Add(User(10));
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 2, Xp = 20 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var guild = await service.GetGuildAsync(100);
+        var guildMembers = await service.GetGuildUsers(100);
+        var guildMember = await service.GetGuildMemberAsync(100, 10);
+        var missingMember = await service.GetGuildMemberAsync(100, 999);
+
+        Assert.True(guild.HasValue);
+        Assert.True(guildMembers.HasValue);
+        Assert.Contains(10, guildMembers.Value.Keys);
+        Assert.True(guildMember.HasValue);
+        Assert.True(missingMember.HasNoValue);
+    }
+
+    [Fact]
+    public async Task RemoveGuildAsync_RemovesExistingGuild()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        await service.RemoveGuildAsync(100);
+        await service.RemoveGuildAsync(999);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(assertDb.Guilds);
+    }
+
+    [Fact]
+    public async Task UpdateGuildPrefixAsync_UpdatesExistingAndReturnsNoneForMissing()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var updated = await service.UpdateGuildPrefixAsync(100, "?");
+        var missing = await service.UpdateGuildPrefixAsync(999, "?");
+
+        Assert.True(updated.HasValue);
+        Assert.Equal("?", updated.Value.Prefix);
+        Assert.True(missing.HasNoValue);
+    }
+
+    [Fact]
+    public async Task DeleteGuildMember_RemovesExistingMember()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.Add(User(10));
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 1, Xp = 0 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        await service.DeleteGuildMember(100, 10);
+        await service.DeleteGuildMember(100, 999);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(assertDb.GuildMembers);
+    }
+
+    [Fact]
+    public async Task CountsBatchesAndRanks_ReturnExpectedValues()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.AddRange(Guild(100), Guild(200), Guild(300));
+            db.Users.AddRange(User(1), User(2), User(3));
+            db.GuildMembers.AddRange(
+                new GuildMember { GuildId = 100, UserId = 1, Level = 3, Xp = 0 },
+                new GuildMember { GuildId = 100, UserId = 2, Level = 2, Xp = 50 },
+                new GuildMember { GuildId = 100, UserId = 3, Level = 2, Xp = 10 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var guildCount = await service.GetTotalGuildCountAsync();
+        var guildBatch = await service.GetGuildBatchAsync(batchSize: 2, skip: 1);
+        var memberBatch = await service.GetGuildMemberBatchAsync(batchSize: 2, skip: 1);
+        var rank = await service.GetGuildMemberRankAsync(3, 100);
+        var missingRank = await service.GetGuildMemberRankAsync(999, 100);
+
+        Assert.Equal(3, guildCount);
+        Assert.Equal([200L, 300L], guildBatch.Select(g => g.GuildId));
+        Assert.Equal(2, memberBatch.Count);
+        Assert.True(rank.HasValue);
+        Assert.Equal(3, rank.Value);
+        Assert.True(missingRank.HasNoValue);
+    }
+
+    [Fact]
+    public async Task UpdateGuildMemberCountAsync_UpdatesExistingGuildOnly()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        await service.UpdateGuildMemberCountAsync(100, 42);
+        await service.UpdateGuildMemberCountAsync(999, 1);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(42, (await assertDb.Guilds.SingleAsync(cancellationToken: TestContext.Current.CancellationToken)).MemberCount);
+    }
+
+    [Fact]
+    public async Task DeleteGuildMembersBulkAsync_RemovesSelectedMembers()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.AddRange(User(1), User(2), User(3));
+            db.GuildMembers.AddRange(
+                new GuildMember { GuildMemberId = 1, GuildId = 100, UserId = 1, Level = 1, Xp = 0 },
+                new GuildMember { GuildMemberId = 2, GuildId = 100, UserId = 2, Level = 1, Xp = 0 },
+                new GuildMember { GuildMemberId = 3, GuildId = 100, UserId = 3, Level = 1, Xp = 0 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        await service.DeleteGuildMembersBulkAsync([1, 3]);
+        await service.DeleteGuildMembersBulkAsync([]);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var remainingIds = await assertDb.GuildMembers
+            .Select(gm => gm.GuildMemberId)
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal([2], remainingIds);
+    }
+
+    [Fact]
+    public async Task SyncGuildFromDiscordAsync_UpdatesChangedFields()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var discordGuild = new Mock<IGuild>();
+        discordGuild.SetupGet(g => g.Name).Returns("Updated");
+        discordGuild.SetupGet(g => g.IconUrl).Returns("https://cdn.example.com/icon.png");
+        var service = CreateService(factory);
+
+        var changed = await service.SyncGuildFromDiscordAsync(Guild(100), discordGuild.Object);
+        var missing = await service.SyncGuildFromDiscordAsync(Guild(999), discordGuild.Object);
+
+        Assert.True(changed);
+        Assert.False(missing);
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var guild = await assertDb.Guilds.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("Updated", guild.GuildName);
+        Assert.Equal("https://cdn.example.com/icon.png", guild.Icon);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
@@ -175,12 +175,14 @@ public class GuildServiceTests
         var guildCount = await service.GetTotalGuildCountAsync();
         var guildBatch = await service.GetGuildBatchAsync(batchSize: 2, skip: 1);
         var memberBatch = await service.GetGuildMemberBatchAsync(batchSize: 2, skip: 1);
+        var guildsForUser = await service.FindGuildsForUser(2);
         var rank = await service.GetGuildMemberRankAsync(3, 100);
         var missingRank = await service.GetGuildMemberRankAsync(999, 100);
 
         Assert.Equal(3, guildCount);
         Assert.Equal([200L, 300L], guildBatch.Select(g => g.GuildId));
         Assert.Equal(2, memberBatch.Count);
+        Assert.Equal([100L], guildsForUser.Select(g => g.GuildId));
         Assert.True(rank.HasValue);
         Assert.Equal(3, rank.Value);
         Assert.True(missingRank.HasNoValue);

--- a/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/GuildServiceTests.cs
@@ -78,6 +78,46 @@ public class GuildServiceTests
     }
 
     [Fact]
+    public async Task AddGuildAsync_CreatesMissingGuildAndCachesIt()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = CreateService(factory, cache);
+
+        await service.AddGuildAsync(100, "New Guild", 42);
+        await service.AddGuildAsync(100, "Ignored", 99);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var guild = await assertDb.Guilds.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(("New Guild", 42), (guild.GuildName, guild.MemberCount));
+        Assert.True(cache.TryGetValue("guild-100", out Guild? cachedGuild));
+        Assert.Equal("New Guild", cachedGuild!.GuildName);
+    }
+
+    [Fact]
+    public async Task AddGuildMemberAsync_CreatesMissingMemberAndCachesIt()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.Add(User(10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+
+        await service.AddGuildMemberAsync(100, 10, "avatar.png");
+        await service.AddGuildMemberAsync(100, 10, "ignored.png");
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var member = await assertDb.GuildMembers.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(("avatar.png", 1, 0), (member.AvatarUrl, member.Level, member.Xp));
+        Assert.True(cache.TryGetValue("guild-member-100-10", out GuildMember? cachedMember));
+        Assert.Equal("avatar.png", cachedMember!.AvatarUrl);
+    }
+
+    [Fact]
     public async Task UpdateGuildPrefixAsync_UpdatesExistingAndReturnsNoneForMissing()
     {
         var factory = new InfrastructureTestDbFactory();
@@ -162,6 +202,55 @@ public class GuildServiceTests
 
         await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         Assert.Equal(42, (await assertDb.Guilds.SingleAsync(cancellationToken: TestContext.Current.CancellationToken)).MemberCount);
+    }
+
+    [Fact]
+    public async Task UpdateGuildMemberAvatarAsync_UpdatesExistingMemberAndIgnoresMissingMember()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.Add(User(10));
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 1, Xp = 0, AvatarUrl = "old.png" });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+
+        await service.UpdateGuildMemberAvatarAsync(100, 10, "new.png");
+        await service.UpdateGuildMemberAvatarAsync(100, 999, "missing.png");
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var member = await assertDb.GuildMembers.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal("new.png", member.AvatarUrl);
+        Assert.True(cache.TryGetValue("guild-member-100-10", out GuildMember? cachedMember));
+        Assert.Equal("new.png", cachedMember!.AvatarUrl);
+    }
+
+    [Fact]
+    public async Task GetOrCreateGuildMemberAsync_UsesCacheDatabaseOrCreatesMember()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(Guild(100));
+            db.Users.AddRange(User(10), User(20));
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 2, Xp = 30, AvatarUrl = "existing.png" });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+
+        var fromDatabase = await service.GetOrCreateGuildMemberAsync(100, 10, "ignored.png");
+        var fromCache = await service.GetOrCreateGuildMemberAsync(100, 10, "ignored-again.png");
+        var created = await service.GetOrCreateGuildMemberAsync(100, 20, "created.png");
+
+        Assert.True(fromDatabase.HasValue);
+        Assert.True(fromCache.HasValue);
+        Assert.True(created.HasValue);
+        Assert.Equal("existing.png", fromCache.Value.AvatarUrl);
+        Assert.Equal(("created.png", 1, 0), (created.Value.AvatarUrl, created.Value.Level, created.Value.Xp));
     }
 
     [Fact]

--- a/tests/dotBento.Infrastructure.Tests/Services/LeaderboardServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/LeaderboardServiceTests.cs
@@ -301,6 +301,21 @@ public class LeaderboardServiceTests
         Assert.Equal("RpsUser3", result.Value[0].Username);
     }
 
+    [Theory]
+    [InlineData(RpsLeaderboardOrder.Ties)]
+    [InlineData((RpsLeaderboardOrder)999)]
+    public async Task GetGlobalRpsLeaderboardAsync_OrdersByRequestedBranch(RpsLeaderboardOrder order)
+    {
+        var factory = new InMemoryDbFactory();
+        await SeedRpsGamesAsync(factory, 3);
+        var service = new LeaderboardService(factory);
+
+        var result = await service.GetGlobalRpsLeaderboardAsync(RpsLeaderboardType.All, order);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(3, result.Value.Count);
+    }
+
     [Fact]
     public async Task GetGlobalRpsLeaderboardAsync_RespectsLimit()
     {

--- a/tests/dotBento.Infrastructure.Tests/Services/PrefixServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/PrefixServiceTests.cs
@@ -1,0 +1,81 @@
+using dotBento.Domain;
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class PrefixServiceTests
+{
+    [Fact]
+    public void StoreGetAndRemovePrefix_UpdatesDictionary()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = new PrefixService(factory);
+        var guildId = (ulong)Random.Shared.NextInt64(100_000, 999_999);
+
+        Assert.Equal(Constants.StartPrefix, service.GetPrefix(guildId));
+
+        service.StorePrefix("?", guildId);
+        Assert.Equal("?", service.GetPrefix(guildId));
+
+        service.StorePrefix("$", guildId);
+        Assert.Equal("$", service.GetPrefix(guildId));
+
+        service.RemovePrefix(guildId);
+        Assert.Equal(Constants.StartPrefix, service.GetPrefix(guildId));
+    }
+
+    [Fact]
+    public void GetPrefix_WithNullGuild_ReturnsDefaultPrefix()
+    {
+        var service = new PrefixService(new InfrastructureTestDbFactory());
+
+        Assert.Equal(Constants.StartPrefix, service.GetPrefix(null));
+    }
+
+    [Fact]
+    public async Task LoadAllPrefixes_LoadsDatabaseGuildPrefixes()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.AddRange(
+                new Guild { GuildId = 101, GuildName = "One", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false },
+                new Guild { GuildId = 102, GuildName = "Two", Prefix = "?", Leaderboard = true, Media = false, Tiktok = false });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new PrefixService(factory);
+
+        await service.LoadAllPrefixes();
+
+        Assert.Equal("!", service.GetPrefix(101));
+        Assert.Equal("?", service.GetPrefix(102));
+    }
+
+    [Fact]
+    public async Task ReloadPrefix_UpdatesOrRemovesStoredPrefix()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(new Guild { GuildId = 201, GuildName = "One", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new PrefixService(factory);
+
+        await service.ReloadPrefix(201);
+        Assert.Equal("!", service.GetPrefix(201));
+
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            var guild = await db.Guilds.SingleAsync(g => g.GuildId == 201, cancellationToken: TestContext.Current.CancellationToken);
+            db.Guilds.Remove(guild);
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        await service.ReloadPrefix(201);
+
+        Assert.Equal(Constants.StartPrefix, service.GetPrefix(201));
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/PrefixServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/PrefixServiceTests.cs
@@ -24,6 +24,9 @@ public class PrefixServiceTests
 
         service.RemovePrefix(guildId);
         Assert.Equal(Constants.StartPrefix, service.GetPrefix(guildId));
+
+        service.RemovePrefix(guildId);
+        Assert.Equal(Constants.StartPrefix, service.GetPrefix(guildId));
     }
 
     [Fact]

--- a/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
@@ -1,0 +1,79 @@
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class SettingsServicesTests
+{
+    [Fact]
+    public async Task GuildSettingService_CreatesUpdatesAndCachesLeaderboardVisibility()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new GuildSettingService(factory, cache);
+
+        var created = await service.GetOrCreateGuildSettingAsync(10);
+        var initiallyPublic = await service.IsLeaderboardPublicAsync(10);
+        var updated = await service.UpdateLeaderboardPublicAsync(10, true);
+        var publicAfterUpdate = await service.IsLeaderboardPublicAsync(10);
+
+        Assert.False(created.LeaderboardPublic);
+        Assert.False(initiallyPublic);
+        Assert.True(updated.LeaderboardPublic);
+        Assert.True(publicAfterUpdate);
+    }
+
+    [Fact]
+    public async Task UserSettingService_CreatesUpdatesCachesAndListsHiddenLeaderboardUsers()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        var service = new UserSettingService(factory, cache);
+
+        var created = await service.GetOrCreateUserSettingAsync(10);
+        var hideBeforeUpdate = await service.ShouldHideCommandsAsync(10);
+        var updated = await service.UpdateUserSettingAsync(10, setting =>
+        {
+            setting.HideSlashCommandCalls = true;
+            setting.ShowOnGlobalLeaderboard = false;
+        });
+        var hideAfterUpdate = await service.ShouldHideCommandsAsync(10);
+        var hiddenUsers = await service.GetHiddenGlobalLeaderboardUserIdsAsync();
+
+        Assert.False(created.HideSlashCommandCalls);
+        Assert.True(created.ShowOnGlobalLeaderboard);
+        Assert.False(hideBeforeUpdate);
+        Assert.True(updated.HideSlashCommandCalls);
+        Assert.False(updated.ShowOnGlobalLeaderboard);
+        Assert.True(hideAfterUpdate);
+        Assert.Contains(10, hiddenUsers);
+    }
+
+    [Fact]
+    public async Task UserSettingService_ReturnsExistingSettings()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.UserSettings.Add(new UserSetting
+            {
+                UserId = 20,
+                HideSlashCommandCalls = true,
+                ShowOnGlobalLeaderboard = false
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new UserSettingService(
+            factory,
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())));
+
+        var setting = await service.GetOrCreateUserSettingAsync(20);
+
+        Assert.True(setting.HideSlashCommandCalls);
+        Assert.False(setting.ShowOnGlobalLeaderboard);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
@@ -103,4 +103,17 @@ public class SettingsServicesTests
         Assert.True(setting.HideSlashCommandCalls);
         Assert.False(setting.ShowOnGlobalLeaderboard);
     }
+
+    [Fact]
+    public async Task UserSettingService_ShouldHideCommandsAsync_UsesCachedValue()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        await cache.SetStringAsync("user-hide-commands-10", "True", TestContext.Current.CancellationToken);
+        var service = new UserSettingService(factory, cache);
+
+        var shouldHide = await service.ShouldHideCommandsAsync(10);
+
+        Assert.True(shouldHide);
+    }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
@@ -28,6 +28,33 @@ public class SettingsServicesTests
     }
 
     [Fact]
+    public async Task GuildSettingService_ReturnsExistingCreatesOnUpdateAndUsesCache()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.GuildSettings.Add(new GuildSetting
+            {
+                GuildId = 10,
+                LeaderboardPublic = true
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new GuildSettingService(factory, cache);
+
+        var existing = await service.GetOrCreateGuildSettingAsync(10);
+        cache.Set("guild-setting-10", false);
+        var cached = await service.IsLeaderboardPublicAsync(10);
+        var createdByUpdate = await service.UpdateLeaderboardPublicAsync(20, true);
+
+        Assert.True(existing.LeaderboardPublic);
+        Assert.False(cached);
+        Assert.Equal(20, createdByUpdate.GuildId);
+        Assert.True(createdByUpdate.LeaderboardPublic);
+    }
+
+    [Fact]
     public async Task UserSettingService_CreatesUpdatesCachesAndListsHiddenLeaderboardUsers()
     {
         var factory = new InfrastructureTestDbFactory();

--- a/tests/dotBento.Infrastructure.Tests/Services/SimplePersistenceServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SimplePersistenceServicesTests.cs
@@ -1,0 +1,131 @@
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class SimplePersistenceServicesTests
+{
+    [Fact]
+    public async Task SupporterService_CountsAndCachesPatreonUsers()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.AddRange(User(1), User(2));
+            db.Patreons.AddRange(
+                new Patreon { UserId = 1, Name = "One", Avatar = "one.png" },
+                new Patreon { UserId = 2, Name = "Two", Avatar = "two.png" });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new SupporterService(factory, cache);
+
+        var count = await service.GetActiveSupporterCountAsync();
+        var found = await service.GetPatreonAsync(1);
+        var cached = await service.GetPatreonAsync(1);
+        var missing = await service.GetPatreonAsync(999);
+
+        Assert.Equal(2, count);
+        Assert.True(found.HasValue);
+        Assert.True(cached.HasValue);
+        Assert.Equal("One", cached.Value.Name);
+        Assert.True(missing.HasNoValue);
+    }
+
+    [Fact]
+    public async Task WeatherService_SavesUpdatesGetsAndDeletesWeather()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = new WeatherService(factory);
+
+        var missing = await service.GetWeatherAsync(10);
+        await service.SaveWeatherAsync(10, "Copenhagen");
+        await service.SaveWeatherAsync(10, "Oslo");
+        var found = await service.GetWeatherAsync(10);
+        await service.DeleteWeatherAsync(999);
+        await service.DeleteWeatherAsync(10);
+        var deleted = await service.GetWeatherAsync(10);
+
+        Assert.True(missing.HasNoValue);
+        Assert.True(found.HasValue);
+        Assert.Equal("Oslo", found.Value.City);
+        Assert.True(deleted.HasNoValue);
+    }
+
+    [Fact]
+    public async Task LastFmService_SavesUpdatesGetsAndDeletesUsername()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        var service = new LastFmService(factory);
+
+        var missing = await service.GetLastFmAsync(10);
+        await service.SaveLastFmAsync(10, "first");
+        await service.SaveLastFmAsync(10, "second");
+        var found = await service.GetLastFmAsync(10);
+        await service.DeleteLastFmAsync(999);
+        await service.DeleteLastFmAsync(10);
+        var deleted = await service.GetLastFmAsync(10);
+
+        Assert.True(missing.HasNoValue);
+        Assert.True(found.HasValue);
+        Assert.Equal("second", found.Value.Lastfm1);
+        Assert.True(deleted.HasNoValue);
+    }
+
+    [Fact]
+    public async Task ReminderService_CreatesGetsUpdatesListsAndDeletesReminders()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new ReminderService(cache, factory);
+        var reminderDate = DateTimeOffset.UtcNow.AddHours(1);
+
+        var created = await service.CreateReminderAsync(10, "first", reminderDate);
+        var byId = await service.GetReminderAsync(10, created.Id);
+        var byContent = await service.GetReminderAsync(10, "first", reminderDate);
+        var allForUser = await service.GetRemindersAsync(10);
+        await service.UpdateReminderAsync(10, created.Id, "updated", reminderDate.AddHours(1));
+        var updated = await service.GetReminderAsync(10, created.Id);
+        await service.UpdateReminderAsync(10, 999, "missing", reminderDate);
+        await service.DeleteReminderAsync(10, 999);
+        await service.DeleteReminderAsync(10, created.Id);
+        var deleted = await service.GetReminderAsync(10, created.Id);
+
+        Assert.True(byId.HasValue);
+        Assert.True(byContent.HasValue);
+        Assert.Single(allForUser);
+        Assert.True(updated.HasValue);
+        Assert.Equal("updated", updated.Value.Reminder1);
+        Assert.True(deleted.HasNoValue);
+    }
+
+    [Fact]
+    public async Task ReminderService_ReturnsRecentReminders()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Reminders.AddRange(
+                new Reminder { UserId = 1, Reminder1 = "past", Date = DateTime.UtcNow.AddMinutes(-1) },
+                new Reminder { UserId = 1, Reminder1 = "future", Date = DateTime.UtcNow.AddMinutes(10) });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = new ReminderService(new MemoryCache(new MemoryCacheOptions()), factory);
+
+        var recent = await service.GetAllRecentRemindersAsync();
+
+        var reminder = Assert.Single(recent);
+        Assert.Equal("past", reminder.Reminder1);
+    }
+
+    private static User User(long id) => new()
+    {
+        UserId = id,
+        Username = $"User{id}",
+        Discriminator = "0001",
+        Level = 1,
+        Xp = 0
+    };
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/TagServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/TagServiceTests.cs
@@ -59,6 +59,73 @@ public sealed class TagServiceTests
         Assert.All(result, name => Assert.Contains("-author-200", name));
     }
 
+    [Fact]
+    public async Task CreateFindUpdateRenameIncrementAndDeleteTagAsync_PersistsChanges()
+    {
+        var factory = new InMemoryDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new TagService(cache, factory);
+
+        var created = await service.CreateTagAsync(100, 1, "hello", "world");
+        var found = await service.FindTagAsync(1, "hello");
+        await service.UpdateTagAsync(100, 1, "hello", "updated");
+        await service.IncrementTagCountAsync(created.TagId);
+        await service.RenameTagAsync(100, 1, "hello", "renamed");
+        var oldName = await service.FindTagAsync(1, "hello");
+        var renamed = await service.FindTagAsync(1, "renamed");
+        await service.DeleteTagAsync(100, 1, "renamed");
+        await service.DeleteTagAsync(100, 1, "missing");
+        await service.UpdateTagAsync(100, 1, "missing", "ignored");
+        await service.RenameTagAsync(100, 1, "missing", "ignored");
+        await service.IncrementTagCountAsync(999);
+        var deleted = await service.FindTagAsync(1, "renamed");
+
+        Assert.Equal("hello", created.Command);
+        Assert.True(found.HasValue);
+        Assert.True(oldName.HasNoValue);
+        Assert.True(renamed.HasValue);
+        Assert.Equal("updated", renamed.Value.Content);
+        Assert.Equal(1, renamed.Value.Count);
+        Assert.True(deleted.HasNoValue);
+    }
+
+    [Fact]
+    public async Task FindTagsAsync_OrdersAndFiltersTags()
+    {
+        var factory = new InMemoryDbFactory();
+        await SeedTagsAsync(factory, 1, 3);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new TagService(cache, factory);
+
+        var alphabetical = await service.FindTagsAsync(1, top: false, Maybe<long>.None);
+        var top = await service.FindTagsAsync(1, top: true, Maybe<long>.None);
+        var author = await service.FindTagsAsync(1, top: false, 200);
+
+        Assert.True(alphabetical.IsSuccess);
+        Assert.Equal(["tag-01-author-100", "tag-02-author-200", "tag-03-author-100"],
+            alphabetical.Value.Select(t => t.Command));
+        Assert.Equal(["tag-03-author-100", "tag-02-author-200", "tag-01-author-100"],
+            top.Value.Select(t => t.Command));
+        var onlyAuthor = Assert.Single(author.Value);
+        Assert.Equal(200, onlyAuthor.UserId);
+    }
+
+    [Fact]
+    public async Task GetRandomTagAsync_ReturnsNoneWhenEmptyAndTagWhenPresent()
+    {
+        var factory = new InMemoryDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = new TagService(cache, factory);
+
+        var missing = await service.GetRandomTagAsync(100, 1);
+        await SeedTagsAsync(factory, 1, 1);
+        var found = await service.GetRandomTagAsync(100, 1);
+
+        Assert.True(missing.HasNoValue);
+        Assert.True(found.HasValue);
+        Assert.Equal(1, found.Value.GuildId);
+    }
+
     private static async Task SeedTagsAsync(IDbContextFactory<BotDbContext> factory, long guildId, int count)
     {
         await using var db = await factory.CreateDbContextAsync();

--- a/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
@@ -226,6 +226,34 @@ public class UserServiceTests
         Assert.Equal((expectedGuildLevel, expectedGuildXp), (guildMember.Level, guildMember.Xp));
     }
 
+    [Theory]
+    [InlineData(nameof(Patreon.Follower), 46)]
+    [InlineData(nameof(Patreon.Enthusiast), 69)]
+    [InlineData(nameof(Patreon.Disciple), 92)]
+    [InlineData(nameof(Patreon.Sponsor), 115)]
+    public async Task AddExperienceAsync_UsesPatreonTierPoints(string tierProperty, int expectedPoints)
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(new Guild { GuildId = 100, GuildName = "Guild", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            db.Users.Add(new User { UserId = 10, Username = "User", Discriminator = "0001", Level = 2, Xp = 0 });
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 2, Xp = 0 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+        var patreon = new Patreon { UserId = 10, Name = "Patron", Avatar = "avatar.png" };
+        typeof(Patreon).GetProperty(tierProperty)!.SetValue(patreon, true);
+
+        await service.AddExperienceAsync(10, 100, patreon.AsMaybe());
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var guildMember = await assertDb.GuildMembers.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(expectedPoints, user.Xp);
+        Assert.Equal(expectedPoints, guildMember.Xp);
+    }
+
     [Fact]
     public async Task AddExperienceAsync_ReturnsWhenUserOrGuildMemberIsMissing()
     {

--- a/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,160 @@
+using dotBento.EntityFramework.Entities;
+using dotBento.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Discord;
+
+namespace dotBento.Infrastructure.Tests.Services;
+
+public class UserServiceTests
+{
+    private static UserService CreateService(
+        InfrastructureTestDbFactory factory,
+        IMemoryCache? cache = null) =>
+        new(cache ?? new MemoryCache(new MemoryCacheOptions()), factory);
+
+    private static User User(long id, int level = 1, int xp = 0) => new()
+    {
+        UserId = id,
+        Username = $"User{id}",
+        Discriminator = "0001",
+        Level = level,
+        Xp = xp
+    };
+
+    [Fact]
+    public async Task GetUserMethods_ReturnExpectedMaybeValuesAndCache()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(User(10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+
+        var fromDatabase = await service.GetUserFromDatabaseAsync(10);
+        var missing = await service.GetUserFromDatabaseAsync(999);
+        var fromGetUser = await service.GetUserAsync(10);
+        var fromCache = await service.GetUserFromCache(10);
+
+        Assert.True(fromDatabase.HasValue);
+        Assert.True(missing.HasNoValue);
+        Assert.True(fromGetUser.HasValue);
+        Assert.True(fromCache.HasValue);
+        Assert.Equal(10, fromCache.Value.UserId);
+    }
+
+    [Fact]
+    public async Task GetMultipleUsersAndAllUsers_ReturnDatabaseUsers()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.AddRange(User(1), User(2), User(3));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var multiple = await service.GetMultipleUsers([1, 3]);
+        var all = await service.GetAllDiscordUserIds();
+        var count = await service.GetTotalDatabaseUserCountAsync();
+
+        Assert.Equal([1L, 3L], multiple.Keys.OrderBy(x => x));
+        Assert.Equal(3, all.Count);
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task DeleteUserAsync_RemovesExistingUserAndCacheEntry()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(User(10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+        _ = await service.GetUserAsync(10);
+
+        await service.DeleteUserAsync(10);
+        await service.DeleteUserAsync(999);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        Assert.Empty(assertDb.Users);
+        Assert.False(cache.TryGetValue("user-10", out _));
+    }
+
+    [Fact]
+    public async Task GetPatreonUserAsync_ReturnsMaybe()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(User(10));
+            db.Patreons.Add(new Patreon { UserId = 10, Name = "Patron", Avatar = "avatar.png", Follower = true });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var found = await service.GetPatreonUserAsync(10);
+        var missing = await service.GetPatreonUserAsync(999);
+
+        Assert.True(found.HasValue);
+        Assert.True(missing.HasNoValue);
+    }
+
+    [Fact]
+    public async Task GetUserRankAsync_ReturnsRankOrNone()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.AddRange(User(1, level: 3, xp: 0), User(2, level: 2, xp: 50), User(3, level: 2, xp: 10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var rank = await service.GetUserRankAsync(3);
+        var missing = await service.GetUserRankAsync(999);
+
+        Assert.True(rank.HasValue);
+        Assert.Equal(3, rank.Value);
+        Assert.True(missing.HasNoValue);
+    }
+
+    [Fact]
+    public async Task GetUserBatchAndUsersWithoutGuilds_ReturnExpectedUsers()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(new Guild { GuildId = 100, GuildName = "Guild", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            db.Users.AddRange(User(1), User(2), User(3));
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 2, Level = 1, Xp = 0 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var batch = await service.GetUserBatchAsync(batchSize: 2, skip: 1);
+        var withoutGuilds = await service.GetUsersWithoutGuilds();
+
+        Assert.Equal([2L, 3L], batch.Select(u => u.UserId));
+        Assert.Equal([1L, 3L], withoutGuilds.OrderBy(x => x));
+    }
+
+    [Fact]
+    public async Task GetNameAsync_UsesGlobalNameWhenGuildIsNull()
+    {
+        var user = new Mock<IUser>();
+        user.SetupGet(x => x.GlobalName).Returns("Global");
+        user.SetupGet(x => x.Username).Returns("Username");
+
+        var name = await UserService.GetNameAsync(null, user.Object);
+
+        Assert.Equal("Global", name);
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
@@ -157,4 +157,39 @@ public class UserServiceTests
 
         Assert.Equal("Global", name);
     }
+
+    [Fact]
+    public async Task GetNameAsync_UsesGuildDisplayNameWhenGuildUserExists()
+    {
+        var user = new Mock<IUser>();
+        user.SetupGet(x => x.Id).Returns(10);
+        user.SetupGet(x => x.GlobalName).Returns("Global");
+        user.SetupGet(x => x.Username).Returns("Username");
+        var guildUser = new Mock<IGuildUser>();
+        guildUser.SetupGet(x => x.DisplayName).Returns("Guild Name");
+        var guild = new Mock<IGuild>();
+        guild.Setup(x => x.GetUserAsync(10, CacheMode.AllowDownload, null))
+            .ReturnsAsync(guildUser.Object);
+
+        var name = await UserService.GetNameAsync(guild.Object, user.Object);
+
+        Assert.Equal("Guild Name", name);
+    }
+
+    [Fact]
+    public async Task GetNameAsync_FallsBackWhenGuildUserIsMissing()
+    {
+        var user = new Mock<IUser>();
+        user.SetupGet(x => x.Id).Returns(10);
+        string nullGlobalName = null!;
+        user.SetupGet(x => x.GlobalName).Returns(nullGlobalName);
+        user.SetupGet(x => x.Username).Returns("Username");
+        var guild = new Mock<IGuild>();
+        guild.Setup(x => x.GetUserAsync(10, CacheMode.AllowDownload, null))
+            .ReturnsAsync((IGuildUser?)null);
+
+        var name = await UserService.GetNameAsync(guild.Object, user.Object);
+
+        Assert.Equal("Username", name);
+    }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
@@ -68,6 +68,25 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task GetTotalDiscordUserCountAsync_SumsGuildMemberCounts()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.AddRange(
+                new Guild { GuildId = 100, GuildName = "One", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false, MemberCount = 10 },
+                new Guild { GuildId = 200, GuildName = "Two", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false, MemberCount = 15 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        var count = await service.GetTotalDiscordUserCountAsync();
+
+        Assert.True(count.HasValue);
+        Assert.Equal(25, count.Value);
+    }
+
+    [Fact]
     public async Task DeleteUserAsync_RemovesExistingUserAndCacheEntry()
     {
         var factory = new InfrastructureTestDbFactory();
@@ -191,5 +210,69 @@ public class UserServiceTests
         var name = await UserService.GetNameAsync(guild.Object, user.Object);
 
         Assert.Equal("Username", name);
+    }
+
+    [Fact]
+    public async Task SyncUserFromDiscordAsync_UpdatesChangedFieldsAndRemovesCacheEntry()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new User
+            {
+                UserId = 10,
+                Username = "Old",
+                Discriminator = "0001",
+                AvatarUrl = "old.png",
+                Level = 1,
+                Xp = 0
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+        _ = await service.GetUserAsync(10);
+        var discordUser = new Mock<IUser>();
+        discordUser.SetupGet(x => x.Username).Returns("New");
+        discordUser.SetupGet(x => x.Discriminator).Returns("1234");
+        discordUser.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 512)).Returns("new.png");
+
+        var changed = await service.SyncUserFromDiscordAsync(new User { UserId = 10 }, discordUser.Object);
+
+        Assert.True(changed);
+        Assert.False(cache.TryGetValue("user-10", out _));
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(("New", "1234", "new.png"), (user.Username, user.Discriminator, user.AvatarUrl));
+    }
+
+    [Fact]
+    public async Task SyncUserFromDiscordAsync_ReturnsFalseForNoChangesOrMissingUser()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(new User
+            {
+                UserId = 10,
+                Username = "Same",
+                Discriminator = "0001",
+                AvatarUrl = "same.png",
+                Level = 1,
+                Xp = 0
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+        var discordUser = new Mock<IUser>();
+        discordUser.SetupGet(x => x.Username).Returns("Same");
+        discordUser.SetupGet(x => x.Discriminator).Returns("0001");
+        discordUser.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 512)).Returns("same.png");
+
+        var unchanged = await service.SyncUserFromDiscordAsync(new User { UserId = 10 }, discordUser.Object);
+        var missing = await service.SyncUserFromDiscordAsync(new User { UserId = 999 }, discordUser.Object);
+
+        Assert.False(unchanged);
+        Assert.False(missing);
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/UserServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using Discord;
+using CSharpFunctionalExtensions;
 
 namespace dotBento.Infrastructure.Tests.Services;
 
@@ -127,6 +128,52 @@ public class UserServiceTests
     }
 
     [Fact]
+    public async Task CreateOrAddUserToCache_CreatesMissingUserAndCachesExistingUser()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        var service = CreateService(factory, cache);
+        var discordUser = new Mock<IUser>();
+        discordUser.SetupGet(x => x.Id).Returns(10);
+        discordUser.SetupGet(x => x.Username).Returns("DiscordUser");
+        discordUser.SetupGet(x => x.Discriminator).Returns("1234");
+        discordUser.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 512)).Returns("avatar.png");
+
+        await service.CreateOrAddUserToCache(discordUser.Object);
+        await service.CreateOrAddUserToCache(discordUser.Object);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(("DiscordUser", "1234", "avatar.png"), (user.Username, user.Discriminator, user.AvatarUrl));
+        Assert.True(cache.TryGetValue("user-10", out User? cachedUser));
+        Assert.Equal(10, cachedUser!.UserId);
+    }
+
+    [Fact]
+    public async Task UpdateUserAvatarAndUsername_UpdateExistingUserAndIgnoreMissingUser()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Users.Add(User(10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory, cache);
+
+        await service.UpdateUserAvatarAsync(10, "new-avatar.png");
+        await service.UpdateUserUsernameAsync(10, "NewName");
+        await service.UpdateUserAvatarAsync(999, "missing.png");
+        await service.UpdateUserUsernameAsync(999, "Missing");
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(("NewName", "new-avatar.png"), (user.Username, user.AvatarUrl));
+        Assert.True(cache.TryGetValue("user-10", out User? cachedUser));
+        Assert.Equal("NewName", cachedUser!.Username);
+    }
+
+    [Fact]
     public async Task GetUserRankAsync_ReturnsRankOrNone()
     {
         var factory = new InfrastructureTestDbFactory();
@@ -143,6 +190,60 @@ public class UserServiceTests
         Assert.True(rank.HasValue);
         Assert.Equal(3, rank.Value);
         Assert.True(missing.HasNoValue);
+    }
+
+    [Theory]
+    [InlineData(false, 23, 1, 73, 1, 73)]
+    [InlineData(true, 115, 2, 0, 2, 0)]
+    public async Task AddExperienceAsync_AddsXpAndLevelsWhenThresholdIsReached(
+        bool sponsor,
+        int expectedPoints,
+        int expectedUserLevel,
+        int expectedUserXp,
+        int expectedGuildLevel,
+        int expectedGuildXp)
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(new Guild { GuildId = 100, GuildName = "Guild", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            db.Users.Add(new User { UserId = 10, Username = "User", Discriminator = "0001", Level = 1, Xp = 50 });
+            db.GuildMembers.Add(new GuildMember { GuildId = 100, UserId = 10, Level = 1, Xp = 50 });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+        var patreon = sponsor
+            ? new Patreon { UserId = 10, Name = "Sponsor", Avatar = "avatar.png", Sponsor = true }.AsMaybe()
+            : Maybe<Patreon>.None;
+
+        await service.AddExperienceAsync(10, 100, patreon);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var guildMember = await assertDb.GuildMembers.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(expectedPoints, sponsor ? 115 : 23);
+        Assert.Equal((expectedUserLevel, expectedUserXp), (user.Level, user.Xp));
+        Assert.Equal((expectedGuildLevel, expectedGuildXp), (guildMember.Level, guildMember.Xp));
+    }
+
+    [Fact]
+    public async Task AddExperienceAsync_ReturnsWhenUserOrGuildMemberIsMissing()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.Guilds.Add(new Guild { GuildId = 100, GuildName = "Guild", Prefix = "!", Leaderboard = true, Media = false, Tiktok = false });
+            db.Users.Add(User(10));
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+        var service = CreateService(factory);
+
+        await service.AddExperienceAsync(10, 100, Maybe<Patreon>.None);
+        await service.AddExperienceAsync(999, 100, Maybe<Patreon>.None);
+
+        await using var assertDb = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var user = await assertDb.Users.SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(0, user.Xp);
     }
 
     [Fact]

--- a/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
@@ -169,6 +169,19 @@ public class StylingUtilitiesTests
         stream.Flush();
         Assert.Equal(1, stream.Read(new byte[1], 0, 1));
         Assert.Equal(1, stream.Position);
+        Assert.Equal(1, stream.Read(new Span<byte>(new byte[1])));
+        Assert.Equal(2, stream.Position);
+    }
+
+    [Fact]
+    public void MaxLengthStream_DisposeDisposesInnerStream()
+    {
+        var innerStream = new TrackingMemoryStream([1, 2, 3]);
+        using (new StylingUtilities.MaxLengthStream(innerStream, maxBytes: 10))
+        {
+        }
+
+        Assert.True(innerStream.IsDisposed);
     }
 
     [Fact]
@@ -238,10 +251,17 @@ public class StylingUtilitiesTests
 internal sealed class TrackingMemoryStream(byte[] buffer) : MemoryStream(buffer)
 {
     public bool IsAsyncDisposed { get; private set; }
+    public bool IsDisposed { get; private set; }
 
     public override async ValueTask DisposeAsync()
     {
         IsAsyncDisposed = true;
         await base.DisposeAsync();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        IsDisposed = true;
+        base.Dispose(disposing);
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
@@ -45,6 +45,54 @@ public class StylingUtilitiesTests
     }
 
     [Fact]
+    public async Task TryGetDominantColorAsync_ReturnsFailure_WhenStatusCodeFails()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var utilities = new StylingUtilities(httpClient);
+
+        var result = await utilities.TryGetDominantColorAsync("http://fake-image-url");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Status code: 404", result.Error);
+    }
+
+    [Fact]
+    public async Task TryGetDominantColorAsync_ReturnsFailure_WhenImageCannotBeDecoded()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>();
+        mockHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ByteArrayContent([1, 2, 3])
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var utilities = new StylingUtilities(httpClient);
+
+        var result = await utilities.TryGetDominantColorAsync("http://fake-image-url");
+
+        Assert.True(result.IsFailure);
+        Assert.Contains("Could not decode image stream", result.Error);
+    }
+
+    [Fact]
     public async Task TryGetDominantColorAsync_ReturnsFailure_WhenHttpThrows()
     {
         // Arrange
@@ -98,6 +146,28 @@ public class StylingUtilitiesTests
 
         Assert.True(result.IsFailure);
         Assert.Contains("Image is too large", result.Error);
+    }
+
+    [Fact]
+    public void MaxLengthStream_DelegatesOperationsAndUnsupportedMembersThrow()
+    {
+        using var innerStream = new MemoryStream([1, 2, 3]);
+        using var stream = new StylingUtilities.MaxLengthStream(innerStream, maxBytes: 10);
+
+        Assert.True(stream.CanRead);
+        Assert.False(stream.CanSeek);
+        Assert.False(stream.CanWrite);
+        Assert.Throws<NotSupportedException>(() => stream.Length);
+        Assert.Equal(0, stream.Position);
+        Assert.Throws<NotSupportedException>(() => stream.Position = 1);
+        Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        Assert.Throws<NotSupportedException>(() => stream.SetLength(1));
+        Assert.Throws<NotSupportedException>(() => stream.Write([1], 0, 1));
+        Assert.Throws<NotSupportedException>(() => stream.Write([1]));
+
+        stream.Flush();
+        Assert.Equal(1, stream.Read(new byte[1], 0, 1));
+        Assert.Equal(1, stream.Position);
     }
 
     [Fact]

--- a/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Utilities/StylingUtilitiesTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Net;
 using dotBento.Infrastructure.Utilities;
 using Moq;
@@ -183,6 +184,39 @@ public class StylingUtilitiesTests
     }
 
     [Fact]
+    public async Task MaxLengthStream_TracksAsyncReadsAndDisposeAsync()
+    {
+        var innerStream = new TrackingMemoryStream([1, 2, 3, 4]);
+        await using var stream = new StylingUtilities.MaxLengthStream(innerStream, maxBytes: 10);
+
+        var arrayBuffer = new byte[2];
+        var arrayRead = await stream.ReadAsync(arrayBuffer, 0, arrayBuffer.Length, TestContext.Current.CancellationToken);
+        var memoryRead = await stream.ReadAsync(new Memory<byte>(new byte[2]), TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, arrayRead);
+        Assert.Equal(2, memoryRead);
+        Assert.Equal(4, stream.Position);
+
+        await stream.DisposeAsync();
+        Assert.True(innerStream.IsAsyncDisposed);
+    }
+
+    [Fact]
+    public void GetSampleInfo_ScalesLargeImagesToMaxDimension()
+    {
+        var method = typeof(StylingUtilities)
+            .GetMethod("GetSampleInfo", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var result = (SKImageInfo)method.Invoke(null, [new SKImageInfo(512, 256)])!;
+
+        Assert.Equal(128, result.Width);
+        Assert.Equal(64, result.Height);
+        Assert.Equal(SKColorType.Rgba8888, result.ColorType);
+        Assert.Equal(SKAlphaType.Premul, result.AlphaType);
+    }
+
+    [Fact]
     public void CalculateDominantColor_ReturnsAverageColor()
     {
         // Arrange
@@ -199,4 +233,15 @@ public class StylingUtilitiesTests
         Assert.Equal(System.Drawing.Color.FromArgb(150, 125, 125), result);
     }
 
+}
+
+internal sealed class TrackingMemoryStream(byte[] buffer) : MemoryStream(buffer)
+{
+    public bool IsAsyncDisposed { get; private set; }
+
+    public override async ValueTask DisposeAsync()
+    {
+        IsAsyncDisposed = true;
+        await base.DisposeAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- add focused Infrastructure service, extension, command, utility, and HTTP API client tests
- add a shared in-memory BotDbContext factory for Infrastructure tests
- cover Last.fm command workflows, profile helper/rendering workflows, user/guild sync and create workflows, game workflows, streaming response wrappers, styling utility branches, bento/settings service branches, and remaining API utility branches
- add small internal seams for ProfileCommands rendering, user/guild socket adapters, and deterministic RPS testing so behavior can be covered without constructing Discord.NET socket types
- exclude narrow Discord.NET socket adapter and PostgreSQL ILike search paths from coverage where behavior is covered through internal seams or requires a relational provider
- fix command-layer validation bugs found while adding coverage:
  - mention filtering no longer strips all tag content
  - reminder duplicate checks now use sanitized content
  - tag rename now checks the old tag before ownership validation
  - RGB colour validation now returns the RGB-specific error before derived hex validation
- document local coverage badge generation and update README coverage badges
- ignore generated coverage report directories

## Coverage
- dotBento.Infrastructure line coverage increased from 19.5% to 99.7% in the merged solution report
- dotBento.WebApi remains 100%
- dotBento.EntityFramework remains 99%

## Verification
- dotnet test tests/dotBento.Infrastructure.Tests
- dotnet test dotBento.sln --settings coverlet.runsettings --collect:"XPlat Code Coverage" --results-directory TestResults/FinalInfrastructureCoverage21
- dotnet reportgenerator -reports:"TestResults/FinalInfrastructureCoverage21/**/coverage.cobertura.xml" -targetdir:"coverage-report-badges" -reporttypes:"Html;TextSummary;Cobertura;Badges"