### PR TITLE
chore(deps): bump Discord.Net family to 3.20.1

### DIFF
--- a/src/dotBento.Bot/dotBento.Bot.csproj
+++ b/src/dotBento.Bot/dotBento.Bot.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
       <PackageReference Include="BotListAPI" Version="5.5.5" />
       <PackageReference Include="CSharpFunctionalExtensions" Version="3.7.0" />
-      <PackageReference Include="Discord.Net" Version="3.19.1" />
+      <PackageReference Include="Discord.Net" Version="3.20.1" />
       <PackageReference Include="DotNetEnv" Version="3.2.0" />
       <PackageReference Include="Fergun.Interactive" Version="1.9.2" />
       <PackageReference Include="Hangfire.Core" Version="1.8.23" />

--- a/src/dotBento.Infrastructure/dotBento.Infrastructure.csproj
+++ b/src/dotBento.Infrastructure/dotBento.Infrastructure.csproj
@@ -9,8 +9,8 @@
 
     <ItemGroup>
       <PackageReference Include="CSharpFunctionalExtensions" Version="3.7.0" />
-      <PackageReference Include="Discord.Net.Core" Version="3.19.1" />
-      <PackageReference Include="Discord.Net.WebSocket" Version="3.19.1" />
+      <PackageReference Include="Discord.Net.Core" Version="3.20.1" />
+      <PackageReference Include="Discord.Net.WebSocket" Version="3.20.1" />
       <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
       <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.8" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />


### PR DESCRIPTION
## Summary

- Bumps `Discord.Net` (meta), `Discord.Net.Core`, and `Discord.Net.WebSocket` together from **3.19.1 → 3.20.1**
- Supersedes Renovate PRs #520 and #521, which each bumped one sub-package in isolation and caused a runtime `TypeLoadException`
- No source code changes required — this is purely a version-alignment fix

## Root cause of the CI failure on #520 / #521

`Discord.Net.Core` 3.20.0 added a new interface member `VoiceChannelId` on `IVoiceState`. When only that package was bumped, the already-loaded `Discord.Net.WebSocket` 3.19.1 `SocketGuildUser` class (which implements the interface) had no implementation for the new member, causing:

```
System.TypeLoadException : Method 'get_VoiceChannelId' in type
'Discord.WebSocket.SocketGuildUser' from assembly
'Discord.Net.WebSocket, Version=3.19.1.0' does not have an implementation.
```

Bumping all three packages together resolves the mismatch.

## Test plan

- [x] `dotnet build dotBento.sln` — 0 errors
- [x] `dotnet test dotBento.sln` — 565 tests pass (was 3 failures on #520 branch)
- [x] `ProfileCommandsTests.GenerateProfileHtml_*` (the 3 failing tests) now green

## Follow-up

Once this is merged, Renovate PRs #520 and #521 can be closed — the target version is already satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)