### PR TITLE
fix: align Docker SDK with global.json

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:10.0.301 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.302 AS build
 WORKDIR /src
 COPY ["src/dotBento.Bot", "dotBento.Bot/"]
 COPY ["src/dotBento.Domain", "dotBento.Domain/"]


### PR DESCRIPTION
## Summary

- update the Docker build stage from .NET SDK 10.0.301 to 10.0.302
- match the SDK required by global.json

## Cause

The Docker pre-release pipeline restored projects before copying global.json, then failed during build after global.json requested 10.0.302 while the image only contained 10.0.301.

## Validation

- reproduced the failure from Docker pre-release run 30176491770
- completed a clean-checkout Docker build through restore, build, publish, and final image export