### PR TITLE
fix: use global avatar for user command

### DIFF
--- a/src/dotBento.Bot/Commands/SharedCommands/AvatarCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/AvatarCommand.cs
@@ -15,8 +15,8 @@ public sealed class AvatarCommand(StylingUtilities stylingUtilities, Serilog.ILo
     public async Task<ResponseModel> UserAvatarCommand(IUser user)
     {
         var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
-        var avatarForColour = user.GetDisplayAvatarUrl(ImageFormat.WebP);
-        var avatarForImage = user.GetDisplayAvatarUrl(size: 2048, format: ImageFormat.Auto);
+        var avatarForColour = user.GetAvatarUrl(ImageFormat.WebP) ?? user.GetDefaultAvatarUrl();
+        var avatarForImage = user.GetAvatarUrl(size: 2048, format: ImageFormat.Auto) ?? user.GetDefaultAvatarUrl();
         var userPfpColour = await GetAvatarColourAsync(avatarForColour);
         var name = user.GlobalName ?? user.Username;
         embed.Embed.WithTitle($"{StringUtilities.AddPossessiveS(name)} User Profile Avatar")

--- a/tests/dotBento.Bot.Tests/Commands/SharedCommands/AvatarCommandTests.cs
+++ b/tests/dotBento.Bot.Tests/Commands/SharedCommands/AvatarCommandTests.cs
@@ -12,21 +12,45 @@ namespace dotBento.Bot.Tests.Commands.SharedCommands;
 public sealed class AvatarCommandTests
 {
     [Fact]
-    public async Task UserAvatarCommand_UsesDisplayAvatar_WhenUserHasNoCustomAvatar()
+    public async Task UserAvatarCommand_UsesGlobalAvatar_InsteadOfGuildDisplayAvatar()
     {
-        const string displayAvatarUrl = "https://cdn.example.com/display-avatar.png";
-        var user = new Mock<IUser>();
+        const string globalAvatarUrl = "https://cdn.example.com/global-avatar.png";
+        var user = new Mock<IGuildUser>();
         user.SetupGet(x => x.GlobalName).Returns("Example");
-        user.Setup(x => x.GetAvatarUrl(ImageFormat.WebP, 128)).Returns((string)null!);
-        user.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 2048)).Returns((string)null!);
-        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.WebP, 128)).Returns(displayAvatarUrl);
-        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.Auto, 2048)).Returns(displayAvatarUrl);
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.WebP, 128))
+            .Returns("https://cdn.example.com/global-avatar.webp");
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 2048)).Returns(globalAvatarUrl);
+        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.WebP, 128))
+            .Returns("https://cdn.example.com/server-avatar.webp");
+        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.Auto, 2048))
+            .Returns("https://cdn.example.com/server-avatar.png");
         var command = CreateCommand(_ => ImageResponse());
 
         var response = await command.UserAvatarCommand(user.Object);
         var embed = response.Embed.Build();
 
-        Assert.Equal(displayAvatarUrl, embed.Image?.Url);
+        Assert.Equal(globalAvatarUrl, embed.Image?.Url);
+    }
+
+    [Fact]
+    public async Task UserAvatarCommand_UsesDefaultAvatar_WhenUserHasNoGlobalAvatar()
+    {
+        const string defaultAvatarUrl = "https://cdn.example.com/default-avatar.png";
+        var user = new Mock<IGuildUser>();
+        user.SetupGet(x => x.GlobalName).Returns("Example");
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.WebP, 128)).Returns((string)null!);
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 2048)).Returns((string)null!);
+        user.Setup(x => x.GetDefaultAvatarUrl()).Returns(defaultAvatarUrl);
+        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.WebP, 128))
+            .Returns("https://cdn.example.com/server-avatar.webp");
+        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.Auto, 2048))
+            .Returns("https://cdn.example.com/server-avatar.png");
+        var command = CreateCommand(_ => ImageResponse());
+
+        var response = await command.UserAvatarCommand(user.Object);
+        var embed = response.Embed.Build();
+
+        Assert.Equal(defaultAvatarUrl, embed.Image?.Url);
     }
 
     [Fact]
@@ -34,9 +58,9 @@ public sealed class AvatarCommandTests
     {
         var user = new Mock<IUser>();
         user.SetupGet(x => x.GlobalName).Returns("Example");
-        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.WebP, 128))
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.WebP, 128))
             .Returns("https://cdn.example.com/avatar.webp");
-        user.Setup(x => x.GetDisplayAvatarUrl(ImageFormat.Auto, 2048))
+        user.Setup(x => x.GetAvatarUrl(ImageFormat.Auto, 2048))
             .Returns("https://cdn.example.com/avatar.png");
         var command = CreateCommand(_ => new HttpResponseMessage(HttpStatusCode.BadGateway));
 


### PR DESCRIPTION
## Summary

- make avatar user use the account-level avatar instead of the guild display avatar
- fall back to Discord's default avatar when the account has no custom avatar
- keep avatar server behavior unchanged so it continues to prefer the guild avatar
- add regression coverage with distinct global, server, and default avatar URLs

## Cause

Discord.NET's GetDisplayAvatarUrl is guild-aware for guild users. The user command receives a guild user from the slash-command context, so it selected that member's server avatar.

## Validation

- reproduced both incorrect selections before the fix
- focused avatar tests: 4 passed
- full solution: 569 passed