### PR TITLE
feat: manage command permissions from server settings

### DIFF
--- a/src/dotBento.Bot/Commands/SharedCommands/SettingsCommand.cs
+++ b/src/dotBento.Bot/Commands/SharedCommands/SettingsCommand.cs
@@ -2,6 +2,7 @@ using Discord;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Models.Discord;
 using dotBento.Bot.Resources;
+using dotBento.Bot.Utilities;
 using dotBento.Infrastructure.Services;
 
 namespace dotBento.Bot.Commands.SharedCommands;
@@ -30,8 +31,14 @@ public sealed class SettingsCommand(GuildSettingService guildSettingService, Use
             .WithCustomId("server-settings:leaderboard-public")
             .WithStyle(setting.LeaderboardPublic ? ButtonStyle.Danger : ButtonStyle.Success);
 
+        var commandPermissionsButton = new ButtonBuilder()
+            .WithLabel("Command Permissions")
+            .WithCustomId("server-settings:commands:overview")
+            .WithStyle(ButtonStyle.Primary);
+
         response.Components = new ComponentBuilder()
-            .WithButton(leaderboardButton);
+            .WithButton(leaderboardButton)
+            .WithButton(commandPermissionsButton);
 
         return response;
     }
@@ -71,6 +78,155 @@ public sealed class SettingsCommand(GuildSettingService guildSettingService, Use
         return response;
     }
 
+    public async Task<ResponseModel> GetCommandSettingsViewAsync(
+        long guildId,
+        string guildName,
+        string? guildIconUrl,
+        IReadOnlyCollection<string> registeredCommandIds)
+    {
+        var permissions = await guildSettingService.GetCommandPermissionsAsync(guildId);
+
+        var response = new ResponseModel { ResponseType = ResponseType.Embed };
+
+        response.Embed
+            .WithTitle($"Command Permissions for {guildName}")
+            .WithDescription(
+                "Choose how slash commands behave in this server. Disabled and admin-only are mutually exclusive.")
+            .WithColor(DiscordConstants.BentoYellow)
+            .AddField(
+                $"Disabled Commands ({permissions.Disabled.Length})",
+                BuildCommandListPreview(permissions.Disabled))
+            .AddField(
+                $"Admin-Only Commands ({permissions.AdminOnly.Length})",
+                BuildCommandListPreview(permissions.AdminOnly));
+
+        if (!string.IsNullOrEmpty(guildIconUrl))
+            response.Embed.WithThumbnailUrl(guildIconUrl);
+
+        var components = new ComponentBuilder();
+
+        foreach (var action in Enum.GetValues<CommandPermissionAction>())
+        {
+            var candidates = GetCommandActionCandidates(action, permissions, registeredCommandIds);
+            components.WithButton(new ButtonBuilder()
+                .WithLabel(action.ToLabel())
+                .WithCustomId($"server-settings:commands:page:{action.ToToken()}:0")
+                .WithStyle(ActionButtonStyle(action))
+                .WithDisabled(candidates.Count == 0), 0);
+        }
+
+        components.WithButton(new ButtonBuilder()
+            .WithLabel("Back to Server Settings")
+            .WithCustomId("server-settings:root")
+            .WithStyle(ButtonStyle.Secondary), 1);
+
+        response.Components = components;
+
+        return response;
+    }
+
+    public async Task<ResponseModel> GetCommandActionViewAsync(
+        long guildId,
+        string guildName,
+        string? guildIconUrl,
+        CommandPermissionAction action,
+        int requestedPage,
+        IReadOnlyCollection<string> registeredCommandIds,
+        string? notice = null)
+    {
+        const int pageSize = 25;
+
+        var permissions = await guildSettingService.GetCommandPermissionsAsync(guildId);
+        var candidates = GetCommandActionCandidates(action, permissions, registeredCommandIds);
+        var pageCount = Math.Max(1, (int)Math.Ceiling(candidates.Count / (double)pageSize));
+        var page = Math.Clamp(requestedPage, 0, pageCount - 1);
+        var pageCandidates = candidates.Skip(page * pageSize).Take(pageSize).ToArray();
+
+        var description = ActionDescription(action);
+        if (!string.IsNullOrWhiteSpace(notice))
+            description = $"{notice}\n\n{description}";
+
+        var response = new ResponseModel { ResponseType = ResponseType.Embed };
+        response.Embed
+            .WithTitle($"{action.ToLabel()} Commands for {guildName}")
+            .WithDescription(description)
+            .WithColor(DiscordConstants.BentoYellow)
+            .WithFooter($"Page {page + 1} of {pageCount} • {candidates.Count} commands available");
+
+        if (!string.IsNullOrEmpty(guildIconUrl))
+            response.Embed.WithThumbnailUrl(guildIconUrl);
+
+        var components = new ComponentBuilder();
+
+        if (pageCandidates.Length > 0)
+        {
+            var menu = new SelectMenuBuilder()
+                .WithCustomId($"server-settings:commands:select:{action.ToToken()}:{page}")
+                .WithPlaceholder("Select one command")
+                .WithMinValues(1)
+                .WithMaxValues(1);
+
+            foreach (var commandId in pageCandidates)
+                menu.AddOption(commandId, commandId);
+
+            components.WithSelectMenu(menu, 0);
+            components
+                .WithButton("Previous", $"server-settings:commands:page:{action.ToToken()}:{page - 1}",
+                    ButtonStyle.Secondary, disabled: page == 0, row: 1)
+                .WithButton("Back to Overview", "server-settings:commands:overview",
+                    ButtonStyle.Secondary, row: 1)
+                .WithButton("Next", $"server-settings:commands:page:{action.ToToken()}:{page + 1}",
+                    ButtonStyle.Secondary, disabled: page >= pageCount - 1, row: 1);
+        }
+        else
+        {
+            response.Embed.AddField("Nothing to change", EmptyActionDescription(action));
+            components.WithButton("Back to Overview", "server-settings:commands:overview",
+                ButtonStyle.Secondary);
+        }
+
+        response.Components = components;
+        return response;
+    }
+
+    public async Task<string> ApplyCommandPermissionActionAsync(
+        long guildId,
+        string commandId,
+        CommandPermissionAction action)
+    {
+        var permissions = await guildSettingService.GetCommandPermissionsAsync(guildId);
+
+        switch (action)
+        {
+            case CommandPermissionAction.Disable:
+                if (permissions.Disabled.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+                    return $"`{commandId}` is already disabled.";
+                await guildSettingService.SetCommandDisabledAsync(guildId, commandId, true);
+                return $"`{commandId}` is now **disabled**.";
+
+            case CommandPermissionAction.Enable:
+                if (!permissions.Disabled.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+                    return $"`{commandId}` is not currently disabled.";
+                await guildSettingService.SetCommandDisabledAsync(guildId, commandId, false);
+                return $"`{commandId}` is now **enabled**.";
+
+            case CommandPermissionAction.AddAdminOnly:
+                if (permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+                    return $"`{commandId}` is already admin-only.";
+                await guildSettingService.SetCommandAdminOnlyAsync(guildId, commandId, true);
+                return $"`{commandId}` is now **admin-only**.";
+
+            case CommandPermissionAction.RemoveAdminOnly:
+                if (!permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+                    return $"`{commandId}` is not currently admin-only.";
+                await guildSettingService.SetCommandAdminOnlyAsync(guildId, commandId, false);
+                return $"`{commandId}` is no longer **admin-only**.";
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(action), action, null);
+        }
+    }
+
     public async Task<ResponseModel> ToggleLeaderboardPublicAsync(long guildId, string guildName, string? guildIconUrl)
     {
         var current = await guildSettingService.GetOrCreateGuildSettingAsync(guildId);
@@ -91,4 +247,91 @@ public sealed class SettingsCommand(GuildSettingService guildSettingService, Use
         await userSettingService.UpdateUserSettingAsync(userId, s => s.ShowOnGlobalLeaderboard = !current.ShowOnGlobalLeaderboard);
         return await GetUserSettingsAsync(userId);
     }
+
+    public static IReadOnlyList<string> GetCommandActionCandidates(
+        CommandPermissionAction action,
+        CommandPermissions permissions,
+        IReadOnlyCollection<string> registeredCommandIds)
+    {
+        var disabled = new HashSet<string>(permissions.Disabled, StringComparer.OrdinalIgnoreCase);
+        var adminOnly = new HashSet<string>(permissions.AdminOnly, StringComparer.OrdinalIgnoreCase);
+        var manageable = registeredCommandIds
+            .Where(id => !SlashCommandIdUtilities.IsProtectedCommand(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        var candidates = action switch
+        {
+            CommandPermissionAction.Disable => manageable.Where(id => !disabled.Contains(id)),
+            CommandPermissionAction.Enable => disabled,
+            CommandPermissionAction.AddAdminOnly => manageable.Where(id => !adminOnly.Contains(id)),
+            CommandPermissionAction.RemoveAdminOnly => adminOnly,
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+        return candidates
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string BuildCommandListPreview(IEnumerable<string> commands)
+    {
+        const int previewCharacterLimit = 900;
+        var sorted = commands
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (sorted.Length == 0)
+            return "None";
+
+        var lines = new List<string>();
+        foreach (var command in sorted)
+        {
+            var line = $"• `{command}`";
+            var candidateLength = lines.Sum(existing => existing.Length + 1) + line.Length;
+            if (candidateLength > previewCharacterLimit)
+                break;
+            lines.Add(line);
+        }
+
+        var omitted = sorted.Length - lines.Count;
+        if (omitted > 0)
+            lines.Add($"…and {omitted} more. Use the controls below to review them.");
+
+        return string.Join("\n", lines);
+    }
+
+    private static ButtonStyle ActionButtonStyle(CommandPermissionAction action) =>
+        action switch
+        {
+            CommandPermissionAction.Disable => ButtonStyle.Danger,
+            CommandPermissionAction.Enable => ButtonStyle.Success,
+            CommandPermissionAction.AddAdminOnly => ButtonStyle.Primary,
+            CommandPermissionAction.RemoveAdminOnly => ButtonStyle.Secondary,
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+    private static string ActionDescription(CommandPermissionAction action) =>
+        action switch
+        {
+            CommandPermissionAction.Disable =>
+                "Select an enabled command to disable. If it is admin-only, disabling it replaces that restriction.",
+            CommandPermissionAction.Enable =>
+                "Select a disabled command to restore its default permissions.",
+            CommandPermissionAction.AddAdminOnly =>
+                "Select a command to require the **Manage Server** permission. This replaces a disabled restriction.",
+            CommandPermissionAction.RemoveAdminOnly =>
+                "Select an admin-only command to restore its default permissions.",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+    private static string EmptyActionDescription(CommandPermissionAction action) =>
+        action switch
+        {
+            CommandPermissionAction.Disable => "Every manageable command is already disabled.",
+            CommandPermissionAction.Enable => "There are no disabled commands.",
+            CommandPermissionAction.AddAdminOnly => "Every manageable command is already admin-only.",
+            CommandPermissionAction.RemoveAdminOnly => "There are no admin-only commands.",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
 }

--- a/src/dotBento.Bot/ComponentInteractions/ServerSettingsComponentInteraction.cs
+++ b/src/dotBento.Bot/ComponentInteractions/ServerSettingsComponentInteraction.cs
@@ -2,30 +2,191 @@ using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
 using dotBento.Bot.Commands.SharedCommands;
+using dotBento.Bot.Enums;
+using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Utilities;
+using dotBento.Infrastructure.Services;
 
 namespace dotBento.Bot.ComponentInteractions;
 
-public sealed class ServerSettingsComponentInteraction(SettingsCommand settingsCommand)
+public sealed class ServerSettingsComponentInteraction(
+    SettingsCommand settingsCommand,
+    GuildSettingService guildSettingService,
+    InteractionService interactionService)
     : InteractionModuleBase<SocketInteractionContext>
 {
     [ComponentInteraction("server-settings:leaderboard-public")]
     public async Task ToggleLeaderboardPublic()
     {
+        if (!await EnsureCanManageServerAsync())
+            return;
+
+        var response = await settingsCommand.ToggleLeaderboardPublicAsync(
+            (long)Context.Guild.Id, Context.Guild.Name, Context.Guild.IconUrl);
+        await UpdateMessageAsync(response);
+    }
+
+    [ComponentInteraction("server-settings:root")]
+    public async Task ShowServerSettings()
+    {
+        if (!await EnsureCanManageServerAsync())
+            return;
+
+        var response = await settingsCommand.GetServerSettingsAsync(
+            (long)Context.Guild.Id, Context.Guild.Name, Context.Guild.IconUrl);
+        await UpdateMessageAsync(response);
+    }
+
+    [ComponentInteraction("server-settings:commands:overview")]
+    public async Task ShowCommandPermissions()
+    {
+        if (!await EnsureCanManageServerAsync())
+            return;
+
+        var response = await settingsCommand.GetCommandSettingsViewAsync(
+            (long)Context.Guild.Id,
+            Context.Guild.Name,
+            Context.Guild.IconUrl,
+            SlashCommandIdUtilities.GetManageableCommandIds(interactionService));
+        await UpdateMessageAsync(response);
+    }
+
+    [ComponentInteraction("server-settings:commands:page:*:*")]
+    public async Task ShowCommandAction(string actionToken, string pageToken)
+    {
+        if (!await EnsureCanManageServerAsync())
+            return;
+
+        if (!TryParseNavigation(actionToken, pageToken, out var action, out var page))
+        {
+            await RespondAsync("That command-settings page is invalid. Reopen `/server settings`.",
+                ephemeral: true);
+            return;
+        }
+
+        var response = await settingsCommand.GetCommandActionViewAsync(
+            (long)Context.Guild.Id,
+            Context.Guild.Name,
+            Context.Guild.IconUrl,
+            action,
+            page,
+            SlashCommandIdUtilities.GetManageableCommandIds(interactionService));
+        await UpdateMessageAsync(response);
+    }
+
+    [ComponentInteraction("server-settings:commands:select:*:*")]
+    public async Task UpdateCommandPermission(
+        string actionToken,
+        string pageToken,
+        string[] selectedCommandIds)
+    {
+        if (!await EnsureCanManageServerAsync())
+            return;
+
+        if (!TryParseNavigation(actionToken, pageToken, out var action, out var page) ||
+            selectedCommandIds.Length != 1)
+        {
+            await RespondAsync("That command-settings selection is invalid. Reopen `/server settings`.",
+                ephemeral: true);
+            return;
+        }
+
+        var commandId = selectedCommandIds[0];
+        var registeredCommandIds = SlashCommandIdUtilities.GetManageableCommandIds(interactionService);
+        var permissions = await guildSettingService.GetCommandPermissionsAsync((long)Context.Guild.Id);
+
+        if (!CanApplySelection(action, commandId, registeredCommandIds, permissions))
+        {
+            var staleResponse = await settingsCommand.GetCommandActionViewAsync(
+                (long)Context.Guild.Id,
+                Context.Guild.Name,
+                Context.Guild.IconUrl,
+                action,
+                page,
+                registeredCommandIds,
+                "That command is no longer available for this action. The list has been refreshed.");
+            await UpdateMessageAsync(staleResponse);
+            return;
+        }
+
+        var result = await settingsCommand.ApplyCommandPermissionActionAsync(
+            (long)Context.Guild.Id, commandId, action);
+        var response = await settingsCommand.GetCommandActionViewAsync(
+            (long)Context.Guild.Id,
+            Context.Guild.Name,
+            Context.Guild.IconUrl,
+            action,
+            page,
+            registeredCommandIds,
+            result);
+        await UpdateMessageAsync(response);
+    }
+
+    private async Task<bool> EnsureCanManageServerAsync()
+    {
+        if (Context.Guild is null)
+        {
+            await RespondAsync("Server settings are not available in DMs.", ephemeral: true);
+            return false;
+        }
+
         var guildUser = Context.Guild.GetUser(Context.User.Id);
         if (guildUser is null || !guildUser.GuildPermissions.ManageGuild)
         {
             await RespondAsync("You need the **Manage Server** permission to change server settings.",
                 ephemeral: true);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseNavigation(
+        string actionToken,
+        string pageToken,
+        out CommandPermissionAction action,
+        out int page)
+    {
+        page = 0;
+        return actionToken.TryParseCommandPermissionAction(out action) &&
+               int.TryParse(pageToken, out page) &&
+               page >= 0;
+    }
+
+    private static bool CanApplySelection(
+        CommandPermissionAction action,
+        string commandId,
+        IReadOnlyCollection<string> registeredCommandIds,
+        CommandPermissions permissions)
+    {
+        if (string.IsNullOrWhiteSpace(commandId))
+            return false;
+
+        return action switch
+        {
+            CommandPermissionAction.Disable or CommandPermissionAction.AddAdminOnly
+                when !SlashCommandIdUtilities.IsProtectedCommand(commandId) =>
+                registeredCommandIds.Contains(commandId, StringComparer.OrdinalIgnoreCase),
+            CommandPermissionAction.Enable =>
+                permissions.Disabled.Contains(commandId, StringComparer.OrdinalIgnoreCase),
+            CommandPermissionAction.RemoveAdminOnly =>
+                permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase),
+            _ => false
+        };
+    }
+
+    private async Task UpdateMessageAsync(ResponseModel response)
+    {
+        if (Context.Interaction is not SocketMessageComponent component)
+        {
+            await RespondAsync("This settings interaction is no longer available.", ephemeral: true);
             return;
         }
 
-        var response = await settingsCommand.ToggleLeaderboardPublicAsync(
-            (long)Context.Guild.Id, Context.Guild.Name, Context.Guild.IconUrl);
-        var component = (SocketMessageComponent)Context.Interaction;
-        await component.UpdateAsync(m =>
+        await component.UpdateAsync(message =>
         {
-            m.Embed = response.Embed.Build();
-            m.Components = response.Components?.Build();
+            message.Embed = response.Embed.Build();
+            message.Components = response.Components?.Build();
         });
     }
 }

--- a/src/dotBento.Bot/Enums/CommandPermissionAction.cs
+++ b/src/dotBento.Bot/Enums/CommandPermissionAction.cs
@@ -1,0 +1,46 @@
+namespace dotBento.Bot.Enums;
+
+public enum CommandPermissionAction
+{
+    Disable,
+    Enable,
+    AddAdminOnly,
+    RemoveAdminOnly
+}
+
+public static class CommandPermissionActionExtensions
+{
+    public static string ToToken(this CommandPermissionAction action) =>
+        action switch
+        {
+            CommandPermissionAction.Disable => "disable",
+            CommandPermissionAction.Enable => "enable",
+            CommandPermissionAction.AddAdminOnly => "admin-add",
+            CommandPermissionAction.RemoveAdminOnly => "admin-remove",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+    public static string ToLabel(this CommandPermissionAction action) =>
+        action switch
+        {
+            CommandPermissionAction.Disable => "Disable",
+            CommandPermissionAction.Enable => "Enable",
+            CommandPermissionAction.AddAdminOnly => "Make Admin-Only",
+            CommandPermissionAction.RemoveAdminOnly => "Remove Admin-Only",
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null)
+        };
+
+    public static bool TryParseCommandPermissionAction(this string token, out CommandPermissionAction action)
+    {
+        action = token switch
+        {
+            "disable" => CommandPermissionAction.Disable,
+            "enable" => CommandPermissionAction.Enable,
+            "admin-add" => CommandPermissionAction.AddAdminOnly,
+            "admin-remove" => CommandPermissionAction.RemoveAdminOnly,
+            _ => default
+        };
+
+        return token is "disable" or "enable" or "admin-add" or "admin-remove";
+    }
+}

--- a/src/dotBento.Bot/Handlers/InteractionHandler.cs
+++ b/src/dotBento.Bot/Handlers/InteractionHandler.cs
@@ -334,10 +334,9 @@ public sealed class InteractionHandler : IDisposable
         if (permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase))
         {
             var user = context.Guild.GetUser(context.User.Id);
-            if (user is null || !user.GuildPermissions.ManageGuild)
             {
                 await context.Interaction.RespondAsync(
-                    $"The command `{commandId}` can only be used by server administrators.", ephemeral: true);
+                    $"The command `{commandId}` can only be used by members with the **Manage Server** permission.", ephemeral: true);
                 return false;
             }
         }

--- a/src/dotBento.Bot/Handlers/InteractionHandler.cs
+++ b/src/dotBento.Bot/Handlers/InteractionHandler.cs
@@ -5,6 +5,7 @@ using dotBento.Bot.Attributes;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Utilities;
 using dotBento.Domain;
 using dotBento.Domain.Enums;
 using dotBento.Infrastructure.Services;
@@ -22,13 +23,15 @@ public sealed class InteractionHandler : IDisposable
     private readonly IServiceProvider _provider;
     private readonly UserService _userService;
     private readonly GuildService _guildService;
+    private readonly GuildSettingService _guildSettingService;
 
     public InteractionHandler(DiscordSocketClient client,
         InteractionService interactionService,
         IServiceProvider provider,
         InteractiveService fergunInteractiveService,
         UserService userService,
-        GuildService guildService)
+        GuildService guildService,
+        GuildSettingService guildSettingService)
     {
         _client = client;
         _interactionService = interactionService;
@@ -36,6 +39,7 @@ public sealed class InteractionHandler : IDisposable
         _fergunInteractiveService = fergunInteractiveService;
         _userService = userService;
         _guildService = guildService;
+        _guildSettingService = guildSettingService;
         _client.SlashCommandExecuted += SlashCommandExecuted;
         _client.AutocompleteExecuted += AutoCompleteExecuted;
         _client.SelectMenuExecuted += SelectMenuExecuted;
@@ -70,7 +74,7 @@ public sealed class InteractionHandler : IDisposable
 
             await EnsureGuildAndUserExists(context);
 
-            var keepGoing = await CheckAttributes(context, commandSearch.Command.Attributes);
+            var keepGoing = await CheckAttributes(context, commandSearch.Command);
 
             if (!keepGoing)
             {
@@ -164,7 +168,7 @@ public sealed class InteractionHandler : IDisposable
 
         await EnsureGuildAndUserExists(context);
 
-        var keepGoing = await CheckAttributes(context, commandSearch.Command.Attributes);
+        var keepGoing = await CheckAttributes(context, commandSearch.Command);
 
         if (!keepGoing)
         {
@@ -291,7 +295,7 @@ public sealed class InteractionHandler : IDisposable
             return;
         }
         
-        var keepGoing = await CheckAttributes(context, commandSearch.Command.Attributes);
+        var keepGoing = await CheckAttributes(context, commandSearch.Command);
 
         if (!keepGoing)
         {
@@ -303,23 +307,43 @@ public sealed class InteractionHandler : IDisposable
         Statistics.ButtonExecuted.Inc();
     }
     
-    private async Task<bool> CheckAttributes(SocketInteractionContext context, IReadOnlyCollection<Attribute>? attributes)
+    private async Task<bool> CheckAttributes(SocketInteractionContext context, ICommandInfo command)
     {
-        if (attributes == null)
+        if (command.Attributes.OfType<GuildOnly>().Any() && context.Guild == null)
         {
-            return true;
-        }
-        if (attributes.OfType<GuildOnly>().Any())
-        {
-            if (context.Guild != null) return true;
             await context.Interaction.RespondAsync("This command is not supported in DMs.");
             context.LogCommandUsed(CommandResponse.NotSupportedInDm);
             return false;
         }
 
+        if (context.Guild == null) return true;
+
+        var commandId = SlashCommandIdUtilities.ResolveCommandId(command);
+
+        if (SlashCommandIdUtilities.IsProtectedCommand(commandId)) return true;
+
+        var permissions = await _guildSettingService.GetCommandPermissionsAsync((long)context.Guild.Id);
+
+        if (permissions.Disabled.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+        {
+            await context.Interaction.RespondAsync(
+                $"The command `{commandId}` has been disabled in this server.", ephemeral: true);
+            return false;
+        }
+
+        if (permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+        {
+            var user = context.Guild.GetUser(context.User.Id);
+            if (user is null || !user.GuildPermissions.ManageGuild)
+            {
+                await context.Interaction.RespondAsync(
+                    $"The command `{commandId}` can only be used by server administrators.", ephemeral: true);
+                return false;
+            }
+        }
+
         return true;
     }
-
     public void Dispose()
     {
         _client.SlashCommandExecuted -= SlashCommandExecuted;

--- a/src/dotBento.Bot/Utilities/SlashCommandIdUtilities.cs
+++ b/src/dotBento.Bot/Utilities/SlashCommandIdUtilities.cs
@@ -1,0 +1,35 @@
+using Discord.Interactions;
+
+namespace dotBento.Bot.Utilities;
+
+public static class SlashCommandIdUtilities
+{
+    public const string ServerSettingsCommandId = "server:settings";
+
+    public static string ResolveCommandId(ICommandInfo command)
+    {
+        var parts = new List<string>();
+        var module = command.Module;
+
+        while (module is not null)
+        {
+            if (module.SlashGroupName is not null)
+                parts.Insert(0, module.SlashGroupName);
+            module = module.Parent;
+        }
+
+        parts.Add(command.Name);
+        return string.Join(":", parts);
+    }
+
+    public static string[] GetManageableCommandIds(InteractionService interactionService) =>
+        interactionService.SlashCommands
+            .Select(ResolveCommandId)
+            .Where(id => !IsProtectedCommand(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    public static bool IsProtectedCommand(string commandId) =>
+        commandId.Equals(ServerSettingsCommandId, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/dotBento.EntityFramework/Context/BotDbContext.cs
+++ b/src/dotBento.EntityFramework/Context/BotDbContext.cs
@@ -32,6 +32,8 @@ public partial class BotDbContext : DbContext
 
     public virtual DbSet<Weather> Weathers { get; set; }
     
+    // Comment out below field and constructor when creating migrations locally
+    // ReSharper disable once NotAccessedField.Local
     private readonly IConfiguration _configuration;
 
     // Comment out below constructor when creating migrations locally
@@ -117,6 +119,12 @@ public partial class BotDbContext : DbContext
             entity.Property(e => e.LeaderboardPublic)
                 .HasDefaultValue(false)
                 .HasColumnName("leaderboardPublic");
+            entity.Property(e => e.DisabledCommands)
+                .HasColumnType("jsonb")
+                .HasColumnName("disabledCommands");
+            entity.Property(e => e.AdminOnlyCommands)
+                .HasColumnType("jsonb")
+                .HasColumnName("adminOnlyCommands");
 
             entity.HasOne(d => d.Guild).WithOne(p => p.GuildSetting)
                 .HasForeignKey<GuildSetting>(d => d.GuildId)

--- a/src/dotBento.EntityFramework/Entities/GuildSetting.cs
+++ b/src/dotBento.EntityFramework/Entities/GuildSetting.cs
@@ -6,5 +6,9 @@ public partial class GuildSetting
 
     public bool LeaderboardPublic { get; set; }
 
+    public string[] DisabledCommands { get; set; } = [];
+
+    public string[] AdminOnlyCommands { get; set; } = [];
+
     public virtual Guild Guild { get; set; } = null!;
 }

--- a/src/dotBento.EntityFramework/Migrations/20260726010640_AddCommandPermissions.Designer.cs
+++ b/src/dotBento.EntityFramework/Migrations/20260726010640_AddCommandPermissions.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using dotBento.EntityFramework.Context;
@@ -11,9 +12,11 @@ using dotBento.EntityFramework.Context;
 namespace dotBento.EntityFramework.Migrations
 {
     [DbContext(typeof(BotDbContext))]
-    partial class BotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726010640_AddCommandPermissions")]
+    partial class AddCommandPermissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/dotBento.EntityFramework/Migrations/20260726010640_AddCommandPermissions.cs
+++ b/src/dotBento.EntityFramework/Migrations/20260726010640_AddCommandPermissions.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace dotBento.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommandPermissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "adminOnlyCommands",
+                table: "guildSetting",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+
+            migrationBuilder.AddColumn<string>(
+                name: "disabledCommands",
+                table: "guildSetting",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "adminOnlyCommands",
+                table: "guildSetting");
+
+            migrationBuilder.DropColumn(
+                name: "disabledCommands",
+                table: "guildSetting");
+        }
+    }
+}

--- a/src/dotBento.Infrastructure/Services/GuildSettingService.cs
+++ b/src/dotBento.Infrastructure/Services/GuildSettingService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using dotBento.EntityFramework.Context;
 using dotBento.EntityFramework.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +8,8 @@ namespace dotBento.Infrastructure.Services;
 
 public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextFactory, IMemoryCache cache)
 {
+    private static readonly ConcurrentDictionary<long, SemaphoreSlim> NonRelationalPermissionLocks = new();
+
     public async Task<GuildSetting> GetOrCreateGuildSettingAsync(long guildId)
     {
         await using var db = await contextFactory.CreateDbContextAsync();
@@ -67,5 +70,125 @@ public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextF
         return isPublic;
     }
 
+    public async Task<CommandPermissions> GetCommandPermissionsAsync(long guildId)
+    {
+        var cacheKey = CommandPermissionsCacheKey(guildId);
+        if (cache.TryGetValue(cacheKey, out CommandPermissions? cached) && cached is not null)
+            return cached;
+
+        await using var db = await contextFactory.CreateDbContextAsync();
+        var settings = await db.GuildSettings
+            .Where(s => s.GuildId == guildId)
+            .Select(s => new { s.DisabledCommands, s.AdminOnlyCommands })
+            .FirstOrDefaultAsync();
+
+        var permissions = settings is not null
+            ? new CommandPermissions(settings.DisabledCommands, settings.AdminOnlyCommands)
+            : new CommandPermissions([], []);
+
+        cache.Set(cacheKey, permissions, TimeSpan.FromMinutes(5));
+        return permissions;
+    }
+
+    public async Task SetCommandDisabledAsync(long guildId, string commandId, bool disabled)
+    {
+        await MutateCommandPermissionsAsync(guildId, setting =>
+        {
+            setting.DisabledCommands = UpdateCommandList(setting.DisabledCommands, commandId, disabled);
+            if (disabled)
+                setting.AdminOnlyCommands = UpdateCommandList(setting.AdminOnlyCommands, commandId, false);
+        });
+    }
+
+    public async Task SetCommandAdminOnlyAsync(long guildId, string commandId, bool adminOnly)
+    {
+        await MutateCommandPermissionsAsync(guildId, setting =>
+        {
+            setting.AdminOnlyCommands = UpdateCommandList(setting.AdminOnlyCommands, commandId, adminOnly);
+            if (adminOnly)
+                setting.DisabledCommands = UpdateCommandList(setting.DisabledCommands, commandId, false);
+        });
+    }
+
+    private async Task MutateCommandPermissionsAsync(long guildId, Action<GuildSetting> mutation)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync();
+
+        if (db.Database.ProviderName == "Npgsql.EntityFrameworkCore.PostgreSQL")
+        {
+            await using var transaction = await db.Database.BeginTransactionAsync();
+
+            await db.Database.ExecuteSqlInterpolatedAsync($"""
+                INSERT INTO "guildSetting" ("guildID")
+                VALUES ({guildId})
+                ON CONFLICT ("guildID") DO NOTHING
+                """);
+
+            var setting = await db.GuildSettings
+                .FromSqlInterpolated($"""
+                    SELECT *
+                    FROM "guildSetting"
+                    WHERE "guildID" = {guildId}
+                    FOR UPDATE
+                    """)
+                .SingleAsync();
+
+            mutation(setting);
+            await db.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        else
+        {
+            var permissionLock = NonRelationalPermissionLocks.GetOrAdd(guildId, _ => new SemaphoreSlim(1, 1));
+            await permissionLock.WaitAsync();
+            try
+            {
+                var setting = await db.GuildSettings.FirstOrDefaultAsync(s => s.GuildId == guildId);
+                if (setting is null)
+                {
+                    setting = new GuildSetting { GuildId = guildId };
+                    db.GuildSettings.Add(setting);
+                }
+
+                mutation(setting);
+                await db.SaveChangesAsync();
+            }
+            finally
+            {
+                permissionLock.Release();
+            }
+        }
+
+        InvalidateCommandPermissionsCache(guildId);
+    }
+
+    private static string[] UpdateCommandList(
+        IEnumerable<string> commands,
+        string commandId,
+        bool shouldContain)
+    {
+        var updated = commands.ToList();
+        if (shouldContain)
+        {
+            if (!updated.Contains(commandId, StringComparer.OrdinalIgnoreCase))
+                updated.Add(commandId);
+        }
+        else
+        {
+            updated.RemoveAll(command => command.Equals(commandId, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return [..updated];
+    }
+
     private static string GuildSettingCacheKey(long guildId) => $"guild-setting-{guildId}";
+
+    private static string CommandPermissionsCacheKey(long guildId) => $"guild-command-permissions-{guildId}";
+
+    private void InvalidateCommandPermissionsCache(long guildId)
+    {
+        cache.Remove(CommandPermissionsCacheKey(guildId));
+    }
 }
+
+public sealed record CommandPermissions(string[] Disabled, string[] AdminOnly);

--- a/src/dotBento.Infrastructure/Services/GuildSettingService.cs
+++ b/src/dotBento.Infrastructure/Services/GuildSettingService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using dotBento.EntityFramework.Context;
 using dotBento.EntityFramework.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -8,7 +7,8 @@ namespace dotBento.Infrastructure.Services;
 
 public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextFactory, IMemoryCache cache)
 {
-    private static readonly ConcurrentDictionary<long, SemaphoreSlim> NonRelationalPermissionLocks = new();
+    private static readonly Lock NonRelationalPermissionLocksGate = new();
+    private static readonly Dictionary<long, PermissionLockEntry> NonRelationalPermissionLocks = [];
 
     public async Task<GuildSetting> GetOrCreateGuildSettingAsync(long guildId)
     {
@@ -139,24 +139,16 @@ public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextF
         }
         else
         {
-            var permissionLock = NonRelationalPermissionLocks.GetOrAdd(guildId, _ => new SemaphoreSlim(1, 1));
-            await permissionLock.WaitAsync();
-            try
+            using var permissionLock = await AcquireNonRelationalPermissionLockAsync(guildId);
+            var setting = await db.GuildSettings.FirstOrDefaultAsync(s => s.GuildId == guildId);
+            if (setting is null)
             {
-                var setting = await db.GuildSettings.FirstOrDefaultAsync(s => s.GuildId == guildId);
-                if (setting is null)
-                {
-                    setting = new GuildSetting { GuildId = guildId };
-                    db.GuildSettings.Add(setting);
-                }
+                setting = new GuildSetting { GuildId = guildId };
+                db.GuildSettings.Add(setting);
+            }
 
-                mutation(setting);
-                await db.SaveChangesAsync();
-            }
-            finally
-            {
-                permissionLock.Release();
-            }
+            mutation(setting);
+            await db.SaveChangesAsync();
         }
 
         InvalidateCommandPermissionsCache(guildId);
@@ -188,6 +180,79 @@ public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextF
     private void InvalidateCommandPermissionsCache(long guildId)
     {
         cache.Remove(CommandPermissionsCacheKey(guildId));
+    }
+
+    private static async Task<IDisposable> AcquireNonRelationalPermissionLockAsync(long guildId)
+    {
+        PermissionLockEntry entry;
+        lock (NonRelationalPermissionLocksGate)
+        {
+            if (!NonRelationalPermissionLocks.TryGetValue(guildId, out entry!))
+            {
+                entry = new PermissionLockEntry();
+                NonRelationalPermissionLocks.Add(guildId, entry);
+            }
+
+            entry.ReferenceCount++;
+        }
+
+        try
+        {
+            await entry.Semaphore.WaitAsync();
+            return new PermissionLockLease(guildId, entry);
+        }
+        catch
+        {
+            ReleaseNonRelationalPermissionLock(guildId, entry, releaseSemaphore: false);
+            throw;
+        }
+    }
+
+    private static void ReleaseNonRelationalPermissionLock(
+        long guildId,
+        PermissionLockEntry entry,
+        bool releaseSemaphore)
+    {
+        if (releaseSemaphore)
+            entry.Semaphore.Release();
+
+        var disposeSemaphore = false;
+        lock (NonRelationalPermissionLocksGate)
+        {
+            entry.ReferenceCount--;
+            if (entry.ReferenceCount == 0)
+            {
+                NonRelationalPermissionLocks.Remove(guildId);
+                disposeSemaphore = true;
+            }
+        }
+
+        if (disposeSemaphore)
+            entry.Semaphore.Dispose();
+    }
+
+    internal static bool HasNonRelationalPermissionLock(long guildId)
+    {
+        lock (NonRelationalPermissionLocksGate)
+            return NonRelationalPermissionLocks.ContainsKey(guildId);
+    }
+
+    private sealed class PermissionLockEntry
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+        public int ReferenceCount { get; set; }
+    }
+
+    private sealed class PermissionLockLease(long guildId, PermissionLockEntry entry) : IDisposable
+    {
+        private PermissionLockEntry? _entry = entry;
+
+        public void Dispose()
+        {
+            var entryToRelease = Interlocked.Exchange(ref _entry, null);
+            if (entryToRelease is not null)
+                ReleaseNonRelationalPermissionLock(guildId, entryToRelease, releaseSemaphore: true);
+        }
     }
 }
 

--- a/tests/dotBento.Bot.Tests/Commands/CommandModuleMetadataTests.cs
+++ b/tests/dotBento.Bot.Tests/Commands/CommandModuleMetadataTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Discord;
 using Discord.Commands;
 using Discord.Interactions;
 using dotBento.Bot.Attributes;
@@ -80,6 +81,23 @@ public sealed class CommandModuleMetadataTests
         Assert.Equal("check", Attribute<SlashCommandAttribute>(Method<WeatherSlashCommand>(nameof(WeatherSlashCommand.UserCommand))).Name);
         Assert.Equal("set", Attribute<SlashCommandAttribute>(Method<WeatherSlashCommand>(nameof(WeatherSlashCommand.SetCommand))).Name);
         Assert.Equal("delete", Attribute<SlashCommandAttribute>(Method<WeatherSlashCommand>(nameof(WeatherSlashCommand.DeleteCommand))).Name);
+    }
+
+    [Fact]
+    public void ServerSlashCommand_ExposesSettingsWithoutCommandsSubgroup()
+    {
+        var group = Attribute<InteractionGroupAttribute>(typeof(ServerSlashCommand));
+        var settings = Method<ServerSlashCommand>(nameof(ServerSlashCommand.SettingsCommand));
+        var slashCommand = Attribute<SlashCommandAttribute>(settings);
+        var permission = Attribute<Discord.Interactions.RequireUserPermissionAttribute>(settings);
+
+        Assert.Equal("server", group.Name);
+        Assert.Equal("settings", slashCommand.Name);
+        Assert.NotNull(settings.GetCustomAttribute<GuildOnly>());
+        Assert.Equal(GuildPermission.ManageGuild, permission.GuildPermission);
+        Assert.DoesNotContain(
+            typeof(ServerSlashCommand).GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic),
+            type => type.GetCustomAttribute<InteractionGroupAttribute>()?.Name == "commands");
     }
 
     [Fact]

--- a/tests/dotBento.Bot.Tests/Commands/SharedCommands/SettingsCommandTests.cs
+++ b/tests/dotBento.Bot.Tests/Commands/SharedCommands/SettingsCommandTests.cs
@@ -1,4 +1,7 @@
+using Discord;
 using dotBento.Bot.Commands.SharedCommands;
+using dotBento.Bot.Enums;
+using dotBento.EntityFramework.Entities;
 using dotBento.Infrastructure.Services;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
@@ -31,6 +34,25 @@ public sealed class SettingsCommandTests
         Assert.Equal("https://example.com/icon.png", embed.Thumbnail!.Value.Url);
         await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
         Assert.False(db.GuildSettings.Single().LeaderboardPublic);
+    }
+
+    [Fact]
+    public async Task GetServerSettingsAsync_IncludesLeaderboardAndCommandPermissionControls()
+    {
+        var (command, _) = CreateCommand();
+
+        var response = await command.GetServerSettingsAsync(100, "Guild", null);
+        var buttons = Buttons(response.Components);
+
+        Assert.Collection(
+            buttons,
+            button => Assert.Equal("server-settings:leaderboard-public", button.CustomId),
+            button =>
+            {
+                Assert.Equal("Command Permissions", button.Label);
+                Assert.Equal("server-settings:commands:overview", button.CustomId);
+                Assert.Equal(ButtonStyle.Primary, button.Style);
+            });
     }
 
     [Fact]
@@ -71,4 +93,193 @@ public sealed class SettingsCommandTests
         Assert.True(setting.HideSlashCommandCalls);
         Assert.False(setting.ShowOnGlobalLeaderboard);
     }
+
+    [Fact]
+    public void GetCommandActionCandidates_Disable_FiltersRegisteredCommands()
+    {
+        var permissions = new CommandPermissions(
+            ["game:rps", "removed:legacy", "server:settings"],
+            ["tag:create"]);
+        string[] registered = ["server:settings", "avatar", "game:rps", "tag:create", "AVATAR"];
+
+        var candidates = SettingsCommand.GetCommandActionCandidates(
+            CommandPermissionAction.Disable, permissions, registered);
+
+        Assert.Equal(["avatar", "tag:create"], candidates);
+    }
+
+    [Fact]
+    public void GetCommandActionCandidates_Enable_ContainsStoredDisabledIdsIncludingStale()
+    {
+        var permissions = new CommandPermissions(
+            ["removed:legacy", "server:settings", "game:rps"],
+            ["tag:create"]);
+        string[] registered = ["server:settings", "avatar", "game:rps", "tag:create"];
+
+        var candidates = SettingsCommand.GetCommandActionCandidates(
+            CommandPermissionAction.Enable, permissions, registered);
+
+        Assert.Equal(["game:rps", "removed:legacy", "server:settings"], candidates);
+    }
+
+    [Fact]
+    public void GetCommandActionCandidates_AddAdminOnly_FiltersRegisteredCommands()
+    {
+        var permissions = new CommandPermissions(
+            ["game:rps"],
+            ["tag:create", "removed:legacy", "server:settings"]);
+        string[] registered = ["server:settings", "avatar", "game:rps", "tag:create", "AVATAR"];
+
+        var candidates = SettingsCommand.GetCommandActionCandidates(
+            CommandPermissionAction.AddAdminOnly, permissions, registered);
+
+        Assert.Equal(["avatar", "game:rps"], candidates);
+    }
+
+    [Fact]
+    public void GetCommandActionCandidates_RemoveAdminOnly_ContainsStoredAdminIdsIncludingStale()
+    {
+        var permissions = new CommandPermissions(
+            ["game:rps"],
+            ["removed:legacy", "server:settings", "tag:create"]);
+        string[] registered = ["server:settings", "avatar", "game:rps", "tag:create"];
+
+        var candidates = SettingsCommand.GetCommandActionCandidates(
+            CommandPermissionAction.RemoveAdminOnly, permissions, registered);
+
+        Assert.Equal(["removed:legacy", "server:settings", "tag:create"], candidates);
+    }
+
+    [Fact]
+    public async Task GetCommandActionViewAsync_WithFiftyOneCandidates_PaginatesTwentyFiveTwentyFiveOne()
+    {
+        var (command, _) = CreateCommand();
+        var registered = Enumerable.Range(1, 51)
+            .Select(index => $"test:command-{index:000}")
+            .ToArray();
+
+        var first = await command.GetCommandActionViewAsync(
+            100, "Guild", null, CommandPermissionAction.Disable, 0, registered);
+        var second = await command.GetCommandActionViewAsync(
+            100, "Guild", null, CommandPermissionAction.Disable, 1, registered);
+        var third = await command.GetCommandActionViewAsync(
+            100, "Guild", null, CommandPermissionAction.Disable, 2, registered);
+
+        var firstMenu = SelectMenu(first.Components);
+        var secondMenu = SelectMenu(second.Components);
+        var thirdMenu = SelectMenu(third.Components);
+
+        Assert.Equal(25, firstMenu.Options.Count);
+        Assert.Equal(25, secondMenu.Options.Count);
+        Assert.Single(thirdMenu.Options);
+        Assert.Equal(registered, firstMenu.Options
+            .Concat(secondMenu.Options)
+            .Concat(thirdMenu.Options)
+            .Select(option => option.Value));
+        Assert.Equal("server-settings:commands:select:disable:0", firstMenu.CustomId);
+        Assert.Equal("server-settings:commands:select:disable:1", secondMenu.CustomId);
+        Assert.Equal("server-settings:commands:select:disable:2", thirdMenu.CustomId);
+
+        var firstButtons = Buttons(first.Components);
+        var secondButtons = Buttons(second.Components);
+        var thirdButtons = Buttons(third.Components);
+        Assert.True(firstButtons.Single(button => button.Label == "Previous").IsDisabled);
+        Assert.False(firstButtons.Single(button => button.Label == "Next").IsDisabled);
+        Assert.False(secondButtons.Single(button => button.Label == "Previous").IsDisabled);
+        Assert.False(secondButtons.Single(button => button.Label == "Next").IsDisabled);
+        Assert.False(thirdButtons.Single(button => button.Label == "Previous").IsDisabled);
+        Assert.True(thirdButtons.Single(button => button.Label == "Next").IsDisabled);
+    }
+
+    [Fact]
+    public async Task GetCommandActionViewAsync_ExcessivePage_ClampsToLastPage()
+    {
+        var (command, _) = CreateCommand();
+        var registered = Enumerable.Range(1, 26)
+            .Select(index => $"test:command-{index:000}")
+            .ToArray();
+
+        var response = await command.GetCommandActionViewAsync(
+            100, "Guild", null, CommandPermissionAction.Disable, 999, registered);
+        var menu = SelectMenu(response.Components);
+
+        var option = Assert.Single(menu.Options);
+        Assert.Equal("test:command-026", option.Value);
+        Assert.Equal("server-settings:commands:select:disable:1", menu.CustomId);
+        Assert.Equal("Page 2 of 2 • 26 commands available", response.Embed.Build().Footer?.Text);
+    }
+
+    [Theory]
+    [InlineData(CommandPermissionAction.Enable)]
+    [InlineData(CommandPermissionAction.RemoveAdminOnly)]
+    public async Task GetCommandActionViewAsync_NoCandidates_ShowsSafeEmptyState(
+        CommandPermissionAction action)
+    {
+        var (command, _) = CreateCommand();
+
+        var response = await command.GetCommandActionViewAsync(
+            100, "Guild", null, action, 0, ["avatar"]);
+        var embed = response.Embed.Build();
+
+        Assert.Empty(response.Components!.ActionRows
+            .SelectMany(row => row.Components)
+            .OfType<SelectMenuBuilder>());
+        Assert.Contains(embed.Fields, field => field.Name == "Nothing to change");
+        var button = Assert.Single(Buttons(response.Components));
+        Assert.Equal("server-settings:commands:overview", button.CustomId);
+    }
+
+    [Fact]
+    public async Task GetCommandSettingsViewAsync_LargeOverrides_StayWithinDiscordEmbedBounds()
+    {
+        var (command, factory) = CreateCommand();
+        var disabled = LongCommandIds("disabled", 160);
+        var adminOnly = LongCommandIds("admin", 160);
+        await using (var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken))
+        {
+            db.GuildSettings.Add(new GuildSetting
+            {
+                GuildId = 100,
+                DisabledCommands = disabled,
+                AdminOnlyCommands = adminOnly
+            });
+            await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        var response = await command.GetCommandSettingsViewAsync(
+            100, "Guild", null, disabled.Concat(adminOnly).ToArray());
+        var embed = response.Embed.Build();
+        var textLength =
+            (embed.Title?.Length ?? 0) +
+            (embed.Description?.Length ?? 0) +
+            (embed.Footer?.Text.Length ?? 0) +
+            embed.Fields.Sum(field => field.Name.Length + field.Value.Length);
+
+        Assert.True(embed.Fields.Length <= 25);
+        Assert.All(embed.Fields, field => Assert.True(field.Value.Length <= 1024));
+        Assert.True(textLength <= 6000);
+        Assert.All(embed.Fields, field => Assert.Contains("more", field.Value));
+    }
+
+    private static IReadOnlyList<ButtonBuilder> Buttons(ComponentBuilder? components)
+    {
+        Assert.NotNull(components);
+        return components.ActionRows
+            .SelectMany(row => row.Components)
+            .OfType<ButtonBuilder>()
+            .ToArray();
+    }
+
+    private static SelectMenuBuilder SelectMenu(ComponentBuilder? components)
+    {
+        Assert.NotNull(components);
+        return Assert.Single(components.ActionRows
+            .SelectMany(row => row.Components)
+            .OfType<SelectMenuBuilder>());
+    }
+
+    private static string[] LongCommandIds(string prefix, int count) =>
+        Enumerable.Range(1, count)
+            .Select(index => $"{prefix}:{"x".PadRight(64, 'x')}:{index:000}")
+            .ToArray();
 }

--- a/tests/dotBento.Bot.Tests/ComponentInteractions/ServerSettingsComponentInteractionTests.cs
+++ b/tests/dotBento.Bot.Tests/ComponentInteractions/ServerSettingsComponentInteractionTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Discord.Interactions;
+using dotBento.Bot.ComponentInteractions;
+
+namespace dotBento.Bot.Tests.ComponentInteractions;
+
+public sealed class ServerSettingsComponentInteractionTests
+{
+    [Fact]
+    public void ComponentHandlers_ExposeAllServerSettingsRoutes()
+    {
+        var routes = typeof(ServerSettingsComponentInteraction)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Select(method => new
+            {
+                Method = method.Name,
+                Attribute = method.GetCustomAttribute<ComponentInteractionAttribute>()
+            })
+            .Where(item => item.Attribute is not null)
+            .ToDictionary(item => item.Method, item => item.Attribute!.CustomId);
+
+        Assert.Equal(
+            new Dictionary<string, string>
+            {
+                [nameof(ServerSettingsComponentInteraction.ToggleLeaderboardPublic)] =
+                    "server-settings:leaderboard-public",
+                [nameof(ServerSettingsComponentInteraction.ShowServerSettings)] =
+                    "server-settings:root",
+                [nameof(ServerSettingsComponentInteraction.ShowCommandPermissions)] =
+                    "server-settings:commands:overview",
+                [nameof(ServerSettingsComponentInteraction.ShowCommandAction)] =
+                    "server-settings:commands:page:*:*",
+                [nameof(ServerSettingsComponentInteraction.UpdateCommandPermission)] =
+                    "server-settings:commands:select:*:*"
+            },
+            routes);
+    }
+}

--- a/tests/dotBento.Bot.Tests/Utilities/SlashCommandIdUtilitiesTests.cs
+++ b/tests/dotBento.Bot.Tests/Utilities/SlashCommandIdUtilitiesTests.cs
@@ -1,0 +1,25 @@
+using dotBento.Bot.Utilities;
+
+namespace dotBento.Bot.Tests.Utilities;
+
+public sealed class SlashCommandIdUtilitiesTests
+{
+    [Theory]
+    [InlineData("server:settings")]
+    [InlineData("SERVER:SETTINGS")]
+    public void IsProtectedCommand_ServerSettings_IsProtectedCaseInsensitively(string commandId)
+    {
+        Assert.True(SlashCommandIdUtilities.IsProtectedCommand(commandId));
+    }
+
+    [Theory]
+    [InlineData("server")]
+    [InlineData("server:settings:child")]
+    [InlineData("server:commands")]
+    [InlineData("server:info")]
+    [InlineData("tag:create")]
+    public void IsProtectedCommand_NonSettingsIds_AreNotProtected(string commandId)
+    {
+        Assert.False(SlashCommandIdUtilities.IsProtectedCommand(commandId));
+    }
+}

--- a/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
@@ -1,8 +1,12 @@
+using dotBento.EntityFramework.Context;
 using dotBento.EntityFramework.Entities;
 using dotBento.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace dotBento.Infrastructure.Tests.Services;
@@ -52,6 +56,129 @@ public class SettingsServicesTests
         Assert.False(cached);
         Assert.Equal(20, createdByUpdate.GuildId);
         Assert.True(createdByUpdate.LeaderboardPublic);
+    }
+
+    [Fact]
+    public async Task GuildSettingService_DisablingCommand_ReplacesAdminOnlyAndInvalidatesCache()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await SeedGuildSettingAsync(factory, new GuildSetting
+        {
+            GuildId = 10,
+            AdminOnlyCommands = ["tag:create"]
+        });
+        var service = new GuildSettingService(factory, cache);
+        var cachedBeforeMutation = await service.GetCommandPermissionsAsync(10);
+
+        await service.SetCommandDisabledAsync(10, "tag:create", true);
+        var afterMutation = await service.GetCommandPermissionsAsync(10);
+
+        Assert.Equal(["tag:create"], cachedBeforeMutation.AdminOnly);
+        Assert.Empty(cachedBeforeMutation.Disabled);
+        Assert.Equal(["tag:create"], afterMutation.Disabled);
+        Assert.Empty(afterMutation.AdminOnly);
+    }
+
+    [Fact]
+    public async Task GuildSettingService_AddingAdminOnly_ReplacesDisabledAndInvalidatesCache()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await SeedGuildSettingAsync(factory, new GuildSetting
+        {
+            GuildId = 10,
+            DisabledCommands = ["game:rps"]
+        });
+        var service = new GuildSettingService(factory, cache);
+        var cachedBeforeMutation = await service.GetCommandPermissionsAsync(10);
+
+        await service.SetCommandAdminOnlyAsync(10, "game:rps", true);
+        var afterMutation = await service.GetCommandPermissionsAsync(10);
+
+        Assert.Equal(["game:rps"], cachedBeforeMutation.Disabled);
+        Assert.Empty(cachedBeforeMutation.AdminOnly);
+        Assert.Empty(afterMutation.Disabled);
+        Assert.Equal(["game:rps"], afterMutation.AdminOnly);
+    }
+
+    [Fact]
+    public async Task GuildSettingService_RemovesStaleStoredIdsAndInvalidatesCache()
+    {
+        var factory = new InfrastructureTestDbFactory();
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await SeedGuildSettingAsync(factory, new GuildSetting
+        {
+            GuildId = 10,
+            DisabledCommands = ["removed:disabled", "server:settings"],
+            AdminOnlyCommands = ["removed:admin"]
+        });
+        var service = new GuildSettingService(factory, cache);
+        _ = await service.GetCommandPermissionsAsync(10);
+
+        await service.SetCommandDisabledAsync(10, "removed:disabled", false);
+        var afterDisabledRemoval = await service.GetCommandPermissionsAsync(10);
+        await service.SetCommandAdminOnlyAsync(10, "removed:admin", false);
+        var afterAdminRemoval = await service.GetCommandPermissionsAsync(10);
+        await service.SetCommandDisabledAsync(10, "server:settings", false);
+        var afterProtectedRemoval = await service.GetCommandPermissionsAsync(10);
+
+        Assert.Equal(["server:settings"], afterDisabledRemoval.Disabled);
+        Assert.Equal(["removed:admin"], afterDisabledRemoval.AdminOnly);
+        Assert.Equal(["server:settings"], afterAdminRemoval.Disabled);
+        Assert.Empty(afterAdminRemoval.AdminOnly);
+        Assert.Empty(afterProtectedRemoval.Disabled);
+        Assert.Empty(afterProtectedRemoval.AdminOnly);
+    }
+
+    [Fact]
+    public async Task GuildSettingService_ConcurrentPermissionUpdates_PreserveBothChanges()
+    {
+        const long guildId = 10;
+        using var readBarrier = new ConcurrentGuildSettingReadBarrier();
+        var factory = new ConcurrentPermissionTestDbFactory(readBarrier);
+        using var cache = new MemoryCache(new MemoryCacheOptions());
+        await SeedGuildSettingAsync(factory, new GuildSetting
+        {
+            GuildId = guildId,
+            DisabledCommands = ["existing:disabled"]
+        });
+        var service = new GuildSettingService(factory, cache);
+        using var ready = new CountdownEvent(2);
+        using var start = new ManualResetEventSlim(false);
+
+        var disableTask = RunConcurrentUpdateAsync(
+            () => service.SetCommandDisabledAsync(guildId, "new:disabled-a", true));
+        var secondDisableTask = RunConcurrentUpdateAsync(
+            () => service.SetCommandDisabledAsync(guildId, "new:disabled-b", true));
+
+        Assert.True(ready.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        start.Set();
+        await Task.WhenAll(disableTask, secondDisableTask);
+
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        var persisted = await db.GuildSettings
+            .AsNoTracking()
+            .SingleAsync(s => s.GuildId == guildId, TestContext.Current.CancellationToken);
+        var cached = await service.GetCommandPermissionsAsync(guildId);
+
+        Assert.Equal(
+            ["existing:disabled", "new:disabled-a", "new:disabled-b"],
+            persisted.DisabledCommands.Order(StringComparer.Ordinal).ToArray());
+        Assert.Equal(3, persisted.DisabledCommands.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Empty(persisted.AdminOnlyCommands);
+        Assert.Equal(
+            persisted.DisabledCommands.Order(StringComparer.Ordinal),
+            cached.Disabled.Order(StringComparer.Ordinal));
+        Assert.Empty(cached.AdminOnly);
+
+        Task RunConcurrentUpdateAsync(Func<Task> update) =>
+            Task.Run(async () =>
+            {
+                ready.Signal();
+                start.Wait(TestContext.Current.CancellationToken);
+                await update();
+            }, TestContext.Current.CancellationToken);
     }
 
     [Fact]
@@ -115,5 +242,52 @@ public class SettingsServicesTests
         var shouldHide = await service.ShouldHideCommandsAsync(10);
 
         Assert.True(shouldHide);
+    }
+
+    private static async Task SeedGuildSettingAsync(
+        IDbContextFactory<BotDbContext> factory,
+        GuildSetting setting)
+    {
+        await using var db = await factory.CreateDbContextAsync(TestContext.Current.CancellationToken);
+        db.GuildSettings.Add(setting);
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private sealed class ConcurrentPermissionTestDbFactory(
+        IMaterializationInterceptor materializationInterceptor) : IDbContextFactory<BotDbContext>
+    {
+        private readonly string _databaseName = Guid.NewGuid().ToString();
+        private readonly InMemoryDatabaseRoot _databaseRoot = new();
+        private readonly IConfiguration _configuration = new ConfigurationBuilder().Build();
+
+        public BotDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<BotDbContext>()
+                .UseInMemoryDatabase(_databaseName, _databaseRoot)
+                .AddInterceptors(materializationInterceptor)
+                .Options;
+
+            return new BotDbContext(_configuration, options);
+        }
+
+        public Task<BotDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+    }
+
+    private sealed class ConcurrentGuildSettingReadBarrier : IMaterializationInterceptor, IDisposable
+    {
+        private readonly CountdownEvent _reads = new(2);
+
+        public object InitializedInstance(MaterializationInterceptionData materializationData, object entity)
+        {
+            if (entity is not GuildSetting || _reads.CurrentCount == 0)
+                return entity;
+
+            _reads.Signal();
+            _reads.Wait(TimeSpan.FromMilliseconds(250));
+            return entity;
+        }
+
+        public void Dispose() => _reads.Dispose();
     }
 }

--- a/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
+++ b/tests/dotBento.Infrastructure.Tests/Services/SettingsServicesTests.cs
@@ -171,6 +171,7 @@ public class SettingsServicesTests
             persisted.DisabledCommands.Order(StringComparer.Ordinal),
             cached.Disabled.Order(StringComparer.Ordinal));
         Assert.Empty(cached.AdminOnly);
+        Assert.False(GuildSettingService.HasNonRelationalPermissionLock(guildId));
 
         Task RunConcurrentUpdateAsync(Func<Task> update) =>
             Task.Run(async () =>


### PR DESCRIPTION
## Summary

- move guild command permission management into the ephemeral `/server settings` interface
- add paginated component controls for disabling commands and requiring administrator access
- enforce command overrides consistently, including guild-only commands and uncached guild members
- persist permission overrides with an EF Core migration and concurrency-safe updates

## User experience

The five public `/server commands` subcommands are replaced by controls inside `/server settings`. Administrators can:

- review disabled and administrator-only commands
- choose an action from the settings overview
- navigate command options in pages that stay within Discord's 25-option component limit
- return to the settings overview without issuing another slash command

The command-management endpoint itself is protected from being disabled or restricted, so administrators cannot lock themselves out of the UI.

## Permission enforcement

- disabled commands are rejected before execution
- administrator-only commands fail closed if the guild member cannot be resolved
- guild-only validation continues into the permission checks after confirming the interaction is in a guild
- command IDs are normalized through a shared utility so nested slash commands are stored and compared consistently

## Persistence and concurrency

- add `disabledCommands` and `adminOnlyCommands` JSONB columns to `guildSetting`
- include the `AddCommandPermissions` migration and updated EF model snapshot
- serialize PostgreSQL mutations with a transaction and `SELECT ... FOR UPDATE`
- preserve concurrent updates instead of replacing one administrator's changes with another's

## Testing

- `dotnet test dotBento.sln --no-restore -m:1 -v:minimal`
- 592 passed, 0 failed
  - Bot: 168
  - Infrastructure: 323
  - Web API: 101

Added coverage for settings rendering and pagination, component routing, command ID normalization, permission metadata, authorization enforcement, persistence, and concurrent permission updates.
