### PR TITLE
fix: persist command permission updates

### DIFF
--- a/src/dotBento.Bot/Handlers/InteractionHandler.cs
+++ b/src/dotBento.Bot/Handlers/InteractionHandler.cs
@@ -334,6 +334,7 @@ public sealed class InteractionHandler : IDisposable
         if (permissions.AdminOnly.Contains(commandId, StringComparer.OrdinalIgnoreCase))
         {
             var user = context.Guild.GetUser(context.User.Id);
+            if (!HasManageGuildPermission(user?.GuildPermissions))
             {
                 await context.Interaction.RespondAsync(
                     $"The command `{commandId}` can only be used by members with the **Manage Server** permission.", ephemeral: true);
@@ -343,6 +344,10 @@ public sealed class InteractionHandler : IDisposable
 
         return true;
     }
+
+    internal static bool HasManageGuildPermission(GuildPermissions? permissions) =>
+        permissions?.ManageGuild == true;
+
     public void Dispose()
     {
         _client.SlashCommandExecuted -= SlashCommandExecuted;

--- a/src/dotBento.Bot/dotBento.Bot.csproj
+++ b/src/dotBento.Bot/dotBento.Bot.csproj
@@ -50,5 +50,9 @@
       <ProjectReference Include="..\dotBento.Infrastructure\dotBento.Infrastructure.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="dotBento.Bot.Tests" />
+    </ItemGroup>
+
 
 </Project>

--- a/src/dotBento.Infrastructure/Services/GuildSettingService.cs
+++ b/src/dotBento.Infrastructure/Services/GuildSettingService.cs
@@ -116,26 +116,31 @@ public sealed class GuildSettingService(IDbContextFactory<BotDbContext> contextF
 
         if (db.Database.ProviderName == "Npgsql.EntityFrameworkCore.PostgreSQL")
         {
-            await using var transaction = await db.Database.BeginTransactionAsync();
+            var executionStrategy = db.Database.CreateExecutionStrategy();
+            await executionStrategy.ExecuteAsync(async () =>
+            {
+                await using var retryDb = await contextFactory.CreateDbContextAsync();
+                await using var transaction = await retryDb.Database.BeginTransactionAsync();
 
-            await db.Database.ExecuteSqlInterpolatedAsync($"""
-                INSERT INTO "guildSetting" ("guildID")
-                VALUES ({guildId})
-                ON CONFLICT ("guildID") DO NOTHING
-                """);
+                await retryDb.Database.ExecuteSqlInterpolatedAsync($"""
+                    INSERT INTO "guildSetting" ("guildID")
+                    VALUES ({guildId})
+                    ON CONFLICT ("guildID") DO NOTHING
+                    """);
 
-            var setting = await db.GuildSettings
-                .FromSqlInterpolated($"""
-                    SELECT *
-                    FROM "guildSetting"
-                    WHERE "guildID" = {guildId}
-                    FOR UPDATE
-                    """)
-                .SingleAsync();
+                var setting = await retryDb.GuildSettings
+                    .FromSqlInterpolated($"""
+                        SELECT *
+                        FROM "guildSetting"
+                        WHERE "guildID" = {guildId}
+                        FOR UPDATE
+                        """)
+                    .SingleAsync();
 
-            mutation(setting);
-            await db.SaveChangesAsync();
-            await transaction.CommitAsync();
+                mutation(setting);
+                await retryDb.SaveChangesAsync();
+                await transaction.CommitAsync();
+            });
         }
         else
         {

--- a/tests/dotBento.Bot.Tests/Handlers/InteractionHandlerTests.cs
+++ b/tests/dotBento.Bot.Tests/Handlers/InteractionHandlerTests.cs
@@ -1,0 +1,18 @@
+using Discord;
+using dotBento.Bot.Handlers;
+
+namespace dotBento.Bot.Tests.Handlers;
+
+public sealed class InteractionHandlerTests
+{
+    [Fact]
+    public void HasManageGuildPermission_RequiresExistingUserWithManageGuildPermission()
+    {
+        var noPermissions = new GuildPermissions(0);
+        var manageGuild = new GuildPermissions((ulong)GuildPermission.ManageGuild);
+
+        Assert.False(InteractionHandler.HasManageGuildPermission(null));
+        Assert.False(InteractionHandler.HasManageGuildPermission(noPermissions));
+        Assert.True(InteractionHandler.HasManageGuildPermission(manageGuild));
+    }
+}


### PR DESCRIPTION
## Summary

- execute PostgreSQL command-permission mutations through the configured EF Core execution strategy
- create a fresh `BotDbContext` for every retry attempt while retaining the row-level lock and atomic update
- restore the `ManageGuild` check for admin-only commands
- add regression coverage for missing, insufficient, and Manage Server permissions

## Why

This is a follow-up to #541. Disabling or restricting a command appeared to do nothing in staging and local development.

The bot configures Npgsql with `EnableRetryOnFailure`, but `GuildSettingService` started and committed its transaction directly. When `SaveChangesAsync` ran, EF Core rejected the user-initiated transaction because it was outside `CreateExecutionStrategy().ExecuteAsync`. The interaction therefore failed before the JSON permission arrays were persisted.

The transaction now runs as one retriable unit. Each attempt gets a fresh context so a retry cannot reuse stale tracked state, while `SELECT ... FOR UPDATE` continues to serialize concurrent changes for a guild.

A separate follow-up edit to the admin-only response text had accidentally removed the conditional permission check. That made every admin-only command reject every user, including users with Manage Server. The condition is restored and covered by a focused test.

## Verification

- reproduced the original `NpgsqlRetryingExecutionStrategy does not support user-initiated transactions` failure against local PostgreSQL
- verified the fixed service persists a diagnostic disabled command through retry-enabled Npgsql, then removes it again
- confirmed the local guild permission row was restored to empty arrays after the check
- `dotnet test tests/dotBento.Infrastructure.Tests`: 323 passed
- `dotnet test tests/dotBento.Bot.Tests`: 169 passed
- `git diff --check` passed