### PR TITLE
feat: export slash commands for documentation

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -85,3 +85,11 @@ jobs:
             # Pull the new image and redeploy the production bot
             docker compose -f $USER_DIR/bento/docker-compose.yml pull bot-prod webapi
             docker compose -f $USER_DIR/bento/docker-compose.yml up -d bot-prod webapi
+
+      - name: Publish documentation for this release
+        env:
+          GH_TOKEN: ${{ secrets.BENTO_DOCS_DISPATCH_TOKEN }}
+        run: |
+          gh api --method POST repos/thebentobot/bento-docs/dispatches \
+            -f event_type=dotbento_release \
+            -f client_payload[ref]="${{ env.NEW_TAG }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,5 +23,7 @@ jobs:
         run: dotnet restore dotBento.sln
       - name: Build
         run: dotnet build dotBento.sln --configuration Release --no-restore
+      - name: Check slash-command documentation manifest
+        run: dotnet run --project tools/dotBento.CommandDocs --configuration Release -- check --input docs/slash-commands.json
       - name: Run tests
         run: dotnet test dotBento.sln --configuration Release --no-build --verbosity normal

--- a/docs/slash-commands.json
+++ b/docs/slash-commands.json
@@ -1,0 +1,2652 @@
+{
+  "schemaVersion": 1,
+  "commands": [
+    {
+      "id": "about:bento",
+      "path": [
+        "about",
+        "bento"
+      ],
+      "invocation": "/about bento",
+      "description": "Show info about Bento",
+      "groupPath": [
+        {
+          "name": "about",
+          "description": "Information about stuff related to Bento"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "avatar:server",
+      "path": [
+        "avatar",
+        "server"
+      ],
+      "invocation": "/avatar server",
+      "description": "Get the avatar of a Server Profile",
+      "groupPath": [
+        {
+          "name": "avatar",
+          "description": "Get the avatar of a user"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show avatar for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "avatar:user",
+      "path": [
+        "avatar",
+        "user"
+      ],
+      "invocation": "/avatar user",
+      "description": "Get the avatar of a User Profile",
+      "groupPath": [
+        {
+          "name": "avatar",
+          "description": "Get the avatar of a user"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show avatar for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "banner",
+      "path": [
+        "banner"
+      ],
+      "invocation": "/banner",
+      "description": "Get the banner of a User Profile",
+      "groupPath": [],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show banner for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "bento",
+      "path": [
+        "bento"
+      ],
+      "invocation": "/bento",
+      "description": "Give a friend a Bento Box",
+      "groupPath": [],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User. Omit to check status",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "choose:list",
+      "path": [
+        "choose",
+        "list"
+      ],
+      "invocation": "/choose list",
+      "description": "Get Bento to choose from a list of options",
+      "groupPath": [
+        {
+          "name": "choose",
+          "description": "Get help choosing something"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "options",
+          "description": "Write a list, separated by commas",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "game:8ball",
+      "path": [
+        "game",
+        "8ball"
+      ],
+      "invocation": "/game 8ball",
+      "description": "Ask the magic 8 ball a question",
+      "groupPath": [
+        {
+          "name": "game",
+          "description": "Play a game"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "question",
+          "description": "Ask the magic 8 ball a question",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "game:roll",
+      "path": [
+        "game",
+        "roll"
+      ],
+      "invocation": "/game roll",
+      "description": "Roll a random number",
+      "groupPath": [
+        {
+          "name": "game",
+          "description": "Play a game"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "min",
+          "description": "The minimum number to roll (default = 1)",
+          "type": "Integer",
+          "required": false,
+          "defaultValue": 1,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "max",
+          "description": "The maximum number to roll (default = 10)",
+          "type": "Integer",
+          "required": false,
+          "defaultValue": 10,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "game:rps",
+      "path": [
+        "game",
+        "rps"
+      ],
+      "invocation": "/game rps",
+      "description": "Play Rock Paper Scissors",
+      "groupPath": [
+        {
+          "name": "game",
+          "description": "Play a game"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "weapon",
+          "description": "Do you pick rock, paper or scissors?",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:collage",
+      "path": [
+        "lastfm",
+        "collage"
+      ],
+      "invocation": "/lastfm collage",
+      "description": "Generate a collage of your top artists, albums, or tracks",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "type",
+          "description": "Type of collage",
+          "type": "String",
+          "required": false,
+          "defaultValue": "Top Artists",
+          "choices": [
+            {
+              "name": "Top Artists",
+              "value": "Top Artists"
+            },
+            {
+              "name": "Top Albums",
+              "value": "Top Albums"
+            },
+            {
+              "name": "Top Tracks",
+              "value": "Top Tracks"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "time-period",
+          "description": "Time period",
+          "type": "String",
+          "required": false,
+          "defaultValue": "Overall",
+          "choices": [
+            {
+              "name": "Overall",
+              "value": "Overall"
+            },
+            {
+              "name": "7 Days",
+              "value": "7 Days"
+            },
+            {
+              "name": "1 Month",
+              "value": "1 Month"
+            },
+            {
+              "name": "3 Months",
+              "value": "3 Months"
+            },
+            {
+              "name": "6 Months",
+              "value": "6 Months"
+            },
+            {
+              "name": "1 Year",
+              "value": "1 Year"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "images",
+          "description": "Number of images to display",
+          "type": "String",
+          "required": false,
+          "defaultValue": "4x4",
+          "choices": [
+            {
+              "name": "1x1",
+              "value": "1x1"
+            },
+            {
+              "name": "2x2",
+              "value": "2x2"
+            },
+            {
+              "name": "3x3",
+              "value": "3x3"
+            },
+            {
+              "name": "4x4",
+              "value": "4x4"
+            },
+            {
+              "name": "5x5",
+              "value": "5x5"
+            },
+            {
+              "name": "6x6",
+              "value": "6x6"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:delete",
+      "path": [
+        "lastfm",
+        "delete"
+      ],
+      "invocation": "/lastfm delete",
+      "description": "Delete your lastfm username",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "lastfm:nowplaying",
+      "path": [
+        "lastfm",
+        "nowplaying"
+      ],
+      "invocation": "/lastfm nowplaying",
+      "description": "Show what you\u0027re currently listening to",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:recenttracks",
+      "path": [
+        "lastfm",
+        "recenttracks"
+      ],
+      "invocation": "/lastfm recenttracks",
+      "description": "Show a user\u0027s recent Last.fm tracks",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show recent tracks for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:save",
+      "path": [
+        "lastfm",
+        "save"
+      ],
+      "invocation": "/lastfm save",
+      "description": "Set your lastfm username",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "username",
+          "description": "For a user who has saved lastfm",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:topalbums",
+      "path": [
+        "lastfm",
+        "topalbums"
+      ],
+      "invocation": "/lastfm topalbums",
+      "description": "Show top albums for a user",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "time-period",
+          "description": "Time period",
+          "type": "String",
+          "required": false,
+          "defaultValue": "Overall",
+          "choices": [
+            {
+              "name": "Overall",
+              "value": "Overall"
+            },
+            {
+              "name": "7 Days",
+              "value": "7 Days"
+            },
+            {
+              "name": "1 Month",
+              "value": "1 Month"
+            },
+            {
+              "name": "3 Months",
+              "value": "3 Months"
+            },
+            {
+              "name": "6 Months",
+              "value": "6 Months"
+            },
+            {
+              "name": "1 Year",
+              "value": "1 Year"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "collage",
+          "description": "Show a collage of your top artists",
+          "type": "Boolean",
+          "required": false,
+          "defaultValue": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:topartists",
+      "path": [
+        "lastfm",
+        "topartists"
+      ],
+      "invocation": "/lastfm topartists",
+      "description": "Show top artists for a user",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "time-period",
+          "description": "Time period",
+          "type": "String",
+          "required": false,
+          "defaultValue": "Overall",
+          "choices": [
+            {
+              "name": "Overall",
+              "value": "Overall"
+            },
+            {
+              "name": "7 Days",
+              "value": "7 Days"
+            },
+            {
+              "name": "1 Month",
+              "value": "1 Month"
+            },
+            {
+              "name": "3 Months",
+              "value": "3 Months"
+            },
+            {
+              "name": "6 Months",
+              "value": "6 Months"
+            },
+            {
+              "name": "1 Year",
+              "value": "1 Year"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "collage",
+          "description": "Show a collage of your top artists",
+          "type": "Boolean",
+          "required": false,
+          "defaultValue": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:toptracks",
+      "path": [
+        "lastfm",
+        "toptracks"
+      ],
+      "invocation": "/lastfm toptracks",
+      "description": "Show top tracks for a user",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "time-period",
+          "description": "Time period",
+          "type": "String",
+          "required": false,
+          "defaultValue": "Overall",
+          "choices": [
+            {
+              "name": "Overall",
+              "value": "Overall"
+            },
+            {
+              "name": "7 Days",
+              "value": "7 Days"
+            },
+            {
+              "name": "1 Month",
+              "value": "1 Month"
+            },
+            {
+              "name": "3 Months",
+              "value": "3 Months"
+            },
+            {
+              "name": "6 Months",
+              "value": "6 Months"
+            },
+            {
+              "name": "1 Year",
+              "value": "1 Year"
+            }
+          ],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "collage",
+          "description": "Show a collage of your top artists",
+          "type": "Boolean",
+          "required": false,
+          "defaultValue": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "lastfm:user",
+      "path": [
+        "lastfm",
+        "user"
+      ],
+      "invocation": "/lastfm user",
+      "description": "Show user info for a user",
+      "groupPath": [
+        {
+          "name": "lastfm",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "For a user who has saved lastfm",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:bento:global",
+      "path": [
+        "leaderboard",
+        "bento",
+        "global"
+      ],
+      "invocation": "/leaderboard bento global",
+      "description": "Global bento leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        },
+        {
+          "name": "bento",
+          "description": "Bento leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:bento:server",
+      "path": [
+        "leaderboard",
+        "bento",
+        "server"
+      ],
+      "invocation": "/leaderboard bento server",
+      "description": "Server bento leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        },
+        {
+          "name": "bento",
+          "description": "Bento leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:global",
+      "path": [
+        "leaderboard",
+        "global"
+      ],
+      "invocation": "/leaderboard global",
+      "description": "Global XP leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:rps:global",
+      "path": [
+        "leaderboard",
+        "rps",
+        "global"
+      ],
+      "invocation": "/leaderboard rps global",
+      "description": "Global RPS leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        },
+        {
+          "name": "rps",
+          "description": "RPS leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "type",
+          "description": "RPS weapon type filter",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "order",
+          "description": "Order by wins, ties, or losses",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:rps:server",
+      "path": [
+        "leaderboard",
+        "rps",
+        "server"
+      ],
+      "invocation": "/leaderboard rps server",
+      "description": "Server RPS leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        },
+        {
+          "name": "rps",
+          "description": "RPS leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "type",
+          "description": "RPS weapon type filter",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "order",
+          "description": "Order by wins, ties, or losses",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:server",
+      "path": [
+        "leaderboard",
+        "server"
+      ],
+      "invocation": "/leaderboard server",
+      "description": "Server XP leaderboard",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "leaderboard:user",
+      "path": [
+        "leaderboard",
+        "user"
+      ],
+      "invocation": "/leaderboard user",
+      "description": "View a user\u0027s ranking summary",
+      "groupPath": [
+        {
+          "name": "leaderboard",
+          "description": "View leaderboards"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a user",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "media:tiktok",
+      "path": [
+        "media",
+        "tiktok"
+      ],
+      "invocation": "/media tiktok",
+      "description": "Retrieve media from a TikTok video",
+      "groupPath": [
+        {
+          "name": "media",
+          "description": "Retrieve media from social platforms"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "url",
+          "description": "TikTok video URL",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "media:twitter",
+      "path": [
+        "media",
+        "twitter"
+      ],
+      "invocation": "/media twitter",
+      "description": "Retrieve media from a Twitter/X post",
+      "groupPath": [
+        {
+          "name": "media",
+          "description": "Retrieve media from social platforms"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "url",
+          "description": "Twitter or X post URL",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "ping",
+      "path": [
+        "ping"
+      ],
+      "invocation": "/ping",
+      "description": "Test Bento\u0027s latency",
+      "groupPath": [],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show the result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:background:colour",
+      "path": [
+        "profile",
+        "background",
+        "colour"
+      ],
+      "invocation": "/profile background colour",
+      "description": "Set your profile background colour (hex)",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "background",
+          "description": "Background settings for your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hex",
+          "description": "Hex colour like #1F2937 or 1F2937",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "opacity",
+          "description": "Optional opacity 0-100",
+          "type": "Integer",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:background:reset",
+      "path": [
+        "profile",
+        "background",
+        "reset"
+      ],
+      "invocation": "/profile background reset",
+      "description": "Reset your background image and colour settings to default",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "background",
+          "description": "Background settings for your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "profile:background:upload",
+      "path": [
+        "profile",
+        "background",
+        "upload"
+      ],
+      "invocation": "/profile background upload",
+      "description": "Upload an image to use as your background",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "background",
+          "description": "Background settings for your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "image",
+          "description": "Upload an image file",
+          "type": "Attachment",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:background:url",
+      "path": [
+        "profile",
+        "background",
+        "url"
+      ],
+      "invocation": "/profile background url",
+      "description": "Set the background image URL for your profile",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "background",
+          "description": "Background settings for your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "url",
+          "description": "Direct image URL (http/https)",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:birthday",
+      "path": [
+        "profile",
+        "birthday"
+      ],
+      "invocation": "/profile birthday",
+      "description": "Set your birthday (month and day only)",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "date",
+          "description": "Your birthday (MM-DD or M/D)",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:board:lastfm",
+      "path": [
+        "profile",
+        "board",
+        "lastfm"
+      ],
+      "invocation": "/profile board lastfm",
+      "description": "Enable or disable your Last.fm board on your profile",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "board",
+          "description": "Enable or disable boards on your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "enabled",
+          "description": "Enable (true) or disable (false)",
+          "type": "Boolean",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:board:xp",
+      "path": [
+        "profile",
+        "board",
+        "xp"
+      ],
+      "invocation": "/profile board xp",
+      "description": "Enable or disable your XP board on your profile",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "board",
+          "description": "Enable or disable boards on your profile"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "enabled",
+          "description": "Enable (true) or disable (false)",
+          "type": "Boolean",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:description",
+      "path": [
+        "profile",
+        "description"
+      ],
+      "invocation": "/profile description",
+      "description": "Set your profile description",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "text",
+          "description": "Your description (max 500 characters)",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:reset:background",
+      "path": [
+        "profile",
+        "reset",
+        "background"
+      ],
+      "invocation": "/profile reset background",
+      "description": "Reset your background image and colour settings to default",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "reset",
+          "description": "Reset profile settings to default"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "profile:reset:birthday",
+      "path": [
+        "profile",
+        "reset",
+        "birthday"
+      ],
+      "invocation": "/profile reset birthday",
+      "description": "Clear your birthday",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "reset",
+          "description": "Reset profile settings to default"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "profile:reset:description",
+      "path": [
+        "profile",
+        "reset",
+        "description"
+      ],
+      "invocation": "/profile reset description",
+      "description": "Clear your profile description",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "reset",
+          "description": "Reset profile settings to default"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "profile:reset:timezone",
+      "path": [
+        "profile",
+        "reset",
+        "timezone"
+      ],
+      "invocation": "/profile reset timezone",
+      "description": "Clear your timezone",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        },
+        {
+          "name": "reset",
+          "description": "Reset profile settings to default"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "profile:timezone",
+      "path": [
+        "profile",
+        "timezone"
+      ],
+      "invocation": "/profile timezone",
+      "description": "Set your profile timezone (IANA/Windows ID)",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "id",
+          "description": "Timezone ID, e.g. Europe/Oslo or Pacific Standard Time",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "profile:user",
+      "path": [
+        "profile",
+        "user"
+      ],
+      "invocation": "/profile user",
+      "description": "Show a user\u0027s Bento profile",
+      "groupPath": [
+        {
+          "name": "profile",
+          "description": "View and edit your Bento profile settings"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "remind:create",
+      "path": [
+        "remind",
+        "create"
+      ],
+      "invocation": "/remind create",
+      "description": "Create a reminder",
+      "groupPath": [
+        {
+          "name": "remind",
+          "description": "Manage reminders for yourself"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "content",
+          "description": "What do you need to be reminded of",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "date",
+          "description": "Write a date for the reminder",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "remind:delete",
+      "path": [
+        "remind",
+        "delete"
+      ],
+      "invocation": "/remind delete",
+      "description": "Delete a reminder",
+      "groupPath": [
+        {
+          "name": "remind",
+          "description": "Manage reminders for yourself"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "reminder-id",
+          "description": "Select a reminder",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "remind:info",
+      "path": [
+        "remind",
+        "info"
+      ],
+      "invocation": "/remind info",
+      "description": "Get information about a reminder",
+      "groupPath": [
+        {
+          "name": "remind",
+          "description": "Manage reminders for yourself"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "reminder-id",
+          "description": "Select a reminder",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "remind:list",
+      "path": [
+        "remind",
+        "list"
+      ],
+      "invocation": "/remind list",
+      "description": "List all your reminders",
+      "groupPath": [
+        {
+          "name": "remind",
+          "description": "Manage reminders for yourself"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "remind:update",
+      "path": [
+        "remind",
+        "update"
+      ],
+      "invocation": "/remind update",
+      "description": "Update a reminder",
+      "groupPath": [
+        {
+          "name": "remind",
+          "description": "Manage reminders for yourself"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "reminder-id",
+          "description": "Select a reminder",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "new-content",
+          "description": "Write a new content for the reminder",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "new-date",
+          "description": "Write a new date for the reminder",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "server:info",
+      "path": [
+        "server",
+        "info"
+      ],
+      "invocation": "/server info",
+      "description": "Show info for the server",
+      "groupPath": [
+        {
+          "name": "server",
+          "description": "Commands for the Discord Server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only show server info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "server:settings",
+      "path": [
+        "server",
+        "settings"
+      ],
+      "invocation": "/server settings",
+      "description": "View and manage server settings",
+      "groupPath": [
+        {
+          "name": "server",
+          "description": "Commands for the Discord Server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [
+        "ManageGuild"
+      ],
+      "options": []
+    },
+    {
+      "id": "server:user",
+      "path": [
+        "server",
+        "user"
+      ],
+      "invocation": "/server user",
+      "description": "Show info for a server user",
+      "groupPath": [
+        {
+          "name": "server",
+          "description": "Commands for the Discord Server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show server user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:create",
+      "path": [
+        "tag",
+        "create"
+      ],
+      "invocation": "/tag create",
+      "description": "Create a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "name",
+          "description": "Write a tag name",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "content",
+          "description": "Write message content",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment1",
+          "description": "Add a video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment2",
+          "description": "Add a video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment3",
+          "description": "Add a video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:delete",
+      "path": [
+        "tag",
+        "delete"
+      ],
+      "invocation": "/tag delete",
+      "description": "Delete a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "name",
+          "description": "Write a tag name",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:get",
+      "path": [
+        "tag",
+        "get"
+      ],
+      "invocation": "/tag get",
+      "description": "Get a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "name",
+          "description": "Write a tag name",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:info",
+      "path": [
+        "tag",
+        "info"
+      ],
+      "invocation": "/tag info",
+      "description": "Get info about a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "name",
+          "description": "Write a tag name",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:list",
+      "path": [
+        "tag",
+        "list"
+      ],
+      "invocation": "/tag list",
+      "description": "Get a list of tags (all by default)",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "top",
+          "description": "List the most used tags",
+          "type": "Boolean",
+          "required": false,
+          "defaultValue": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "by-author",
+          "description": "List tags by tags author",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:random",
+      "path": [
+        "tag",
+        "random"
+      ],
+      "invocation": "/tag random",
+      "description": "Get a random tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:rename",
+      "path": [
+        "tag",
+        "rename"
+      ],
+      "invocation": "/tag rename",
+      "description": "Rename a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "old-name",
+          "description": "Write the name of the tag you want to rename",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "new-name",
+          "description": "Write the new name of the tag",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:search",
+      "path": [
+        "tag",
+        "search"
+      ],
+      "invocation": "/tag search",
+      "description": "Search for a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "query",
+          "description": "Search for a tag by name and content",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tag:update",
+      "path": [
+        "tag",
+        "update"
+      ],
+      "invocation": "/tag update",
+      "description": "Update a tag",
+      "groupPath": [
+        {
+          "name": "tag",
+          "description": "Tags for the server"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "name",
+          "description": "Write the name of the tag you want to update",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "content",
+          "description": "Update message content",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment1",
+          "description": "Update video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment2",
+          "description": "Update video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment3",
+          "description": "Update video or photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only the result of the message to you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tools:colour",
+      "path": [
+        "tools",
+        "colour"
+      ],
+      "invocation": "/tools colour",
+      "description": "Get the colour of a hex code or RGB",
+      "groupPath": [
+        {
+          "name": "tools",
+          "description": "Small tools for convenience"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "colour",
+          "description": "Hex code or RGB separated by commas",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show colour for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tools:dominantcolour",
+      "path": [
+        "tools",
+        "dominantcolour"
+      ],
+      "invocation": "/tools dominantcolour",
+      "description": "Get the dominant colour of an image, either by URL or by attachment",
+      "groupPath": [
+        {
+          "name": "tools",
+          "description": "Small tools for convenience"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "url",
+          "description": "URL of the image",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "attachment",
+          "description": "Add a photo",
+          "type": "Attachment",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show colour for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "tools:timezone",
+      "path": [
+        "tools",
+        "timezone"
+      ],
+      "invocation": "/tools timezone",
+      "description": "Show the current time in a timezone",
+      "groupPath": [
+        {
+          "name": "tools",
+          "description": "Small tools for convenience"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "timezone",
+          "description": "Timezone to look up, e.g. Europe/Copenhagen",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "compare",
+          "description": "Timezone to compare against (defaults to your profile timezone if set)",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": true,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show this result for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "urban",
+      "path": [
+        "urban"
+      ],
+      "invocation": "/urban",
+      "description": "Search Urban Dictionary for a term",
+      "groupPath": [],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "define",
+          "description": "What do you want defined?",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "user:info",
+      "path": [
+        "user",
+        "info"
+      ],
+      "invocation": "/user info",
+      "description": "Show info for a user",
+      "groupPath": [
+        {
+          "name": "user",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "user:profile",
+      "path": [
+        "user",
+        "profile"
+      ],
+      "invocation": "/user profile",
+      "description": "Show a user\u0027s Bento profile",
+      "groupPath": [
+        {
+          "name": "user",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": true,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "user",
+          "description": "Pick a User",
+          "type": "User",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show user info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "user:settings",
+      "path": [
+        "user",
+        "settings"
+      ],
+      "invocation": "/user settings",
+      "description": "View and manage your personal settings",
+      "groupPath": [
+        {
+          "name": "user",
+          "description": "Commands for Discord Users"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "weather:check",
+      "path": [
+        "weather",
+        "check"
+      ],
+      "invocation": "/weather check",
+      "description": "Check the weather for a user",
+      "groupPath": [
+        {
+          "name": "weather",
+          "description": "Check the weather!"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "city",
+          "description": "Check the weather in a city. Add country if it returns falsely",
+          "type": "String",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        },
+        {
+          "name": "hide",
+          "description": "Only show weather info for you",
+          "type": "Boolean",
+          "required": false,
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    },
+    {
+      "id": "weather:delete",
+      "path": [
+        "weather",
+        "delete"
+      ],
+      "invocation": "/weather delete",
+      "description": "Delete the city to check the weather for",
+      "groupPath": [
+        {
+          "name": "weather",
+          "description": "Check the weather!"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": []
+    },
+    {
+      "id": "weather:set",
+      "path": [
+        "weather",
+        "set"
+      ],
+      "invocation": "/weather set",
+      "description": "Set the city to check the weather for",
+      "groupPath": [
+        {
+          "name": "weather",
+          "description": "Check the weather!"
+        }
+      ],
+      "guildOnly": false,
+      "requiredUserPermissions": [],
+      "options": [
+        {
+          "name": "city",
+          "description": "Set the city to check the weather for",
+          "type": "String",
+          "required": true,
+          "defaultValue": "",
+          "choices": [],
+          "autocomplete": false,
+          "channelTypes": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/dotBento.Bot/Commands/SlashCommands/LastFmSlashCommand.cs
+++ b/src/dotBento.Bot/Commands/SlashCommands/LastFmSlashCommand.cs
@@ -194,11 +194,11 @@ public sealed class LastFmSlashCommand(InteractiveService interactiveService, La
             await lastFmCommand.GetUserInfo((long)user.Id, username, userAvatar), hide ?? await userSettingService.ShouldHideCommandsAsync((long)Context.User.Id));
     }
 
-    [SlashCommand("recenttracks", "Show user info for a user")]
+    [SlashCommand("recenttracks", "Show a user's recent Last.fm tracks")]
     public async Task RecentTracksCommand(
         [Summary("user", "For a user who has saved lastfm")]
         SocketUser? user = null,
-        [Summary("hide", "Only show user info for you")]
+        [Summary("hide", "Only show recent tracks for you")]
         bool? hide = null)
     {
         user ??= Context.User;

--- a/tests/dotBento.Bot.Tests/CommandDocs/CommandManifestBuilderTests.cs
+++ b/tests/dotBento.Bot.Tests/CommandDocs/CommandManifestBuilderTests.cs
@@ -1,0 +1,104 @@
+using dotBento.CommandDocs;
+
+namespace dotBento.Bot.Tests.CommandDocs;
+
+public sealed class CommandManifestBuilderTests
+{
+    [Fact]
+    public async Task BuildAsync_ExportsEverySlashCommandInInvocationOrder()
+    {
+        var manifest = await CommandManifestBuilder.BuildAsync();
+
+        Assert.Equal(1, manifest.SchemaVersion);
+        Assert.Equal(69, manifest.Commands.Count);
+        Assert.Equal(
+            manifest.Commands.Select(command => command.Invocation).Order(StringComparer.Ordinal),
+            manifest.Commands.Select(command => command.Invocation));
+        Assert.Equal(manifest.Commands.Count, manifest.Commands.Select(command => command.Id).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task BuildAsync_RepresentsUngroupedAndNestedCommandPaths()
+    {
+        var manifest = await CommandManifestBuilder.BuildAsync();
+
+        var ungrouped = Assert.Single(manifest.Commands, command => command.Id == "ping");
+        Assert.Equal(["ping"], ungrouped.Path);
+        Assert.Equal("/ping", ungrouped.Invocation);
+        Assert.Empty(ungrouped.GroupPath);
+
+        var nested = Assert.Single(manifest.Commands, command => command.Id == "profile:background:colour");
+        Assert.Equal(["profile", "background", "colour"], nested.Path);
+        Assert.Equal("/profile background colour", nested.Invocation);
+        Assert.Collection(
+            nested.GroupPath,
+            group =>
+            {
+                Assert.Equal("profile", group.Name);
+                Assert.Equal("View and edit your Bento profile settings", group.Description);
+            },
+            group =>
+            {
+                Assert.Equal("background", group.Name);
+                Assert.Equal("Background settings for your profile", group.Description);
+            });
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExportsGuildOnlyAndManageGuildRequirements()
+    {
+        var manifest = await CommandManifestBuilder.BuildAsync();
+
+        var serverSettings = Assert.Single(manifest.Commands, command => command.Id == "server:settings");
+        Assert.True(serverSettings.GuildOnly);
+        Assert.Equal(["ManageGuild"], serverSettings.RequiredUserPermissions);
+        Assert.Empty(serverSettings.Options);
+
+        var serverInfo = Assert.Single(manifest.Commands, command => command.Id == "server:info");
+        Assert.True(serverInfo.GuildOnly);
+        Assert.Empty(serverInfo.RequiredUserPermissions);
+    }
+
+    [Fact]
+    public async Task BuildAsync_ExportsDefaultsChoicesAutocompleteAndRequiredOptions()
+    {
+        var manifest = await CommandManifestBuilder.BuildAsync();
+
+        var roll = Assert.Single(manifest.Commands, command => command.Id == "game:roll");
+        var minimum = Assert.Single(roll.Options, option => option.Name == "min");
+        Assert.Equal("Integer", minimum.Type);
+        Assert.False(minimum.Required);
+        Assert.Equal(1, minimum.DefaultValue);
+
+        var topArtists = Assert.Single(manifest.Commands, command => command.Id == "lastfm:topartists");
+        var timePeriod = Assert.Single(topArtists.Options, option => option.Name == "time-period");
+        Assert.Equal("Overall", timePeriod.DefaultValue);
+        Assert.Equal(
+            ["Overall", "7 Days", "1 Month", "3 Months", "6 Months", "1 Year"],
+            timePeriod.Choices.Select(choice => choice.Name));
+        Assert.Equal(timePeriod.Choices.Select(choice => choice.Name), timePeriod.Choices.Select(choice => choice.Value));
+
+        var timezone = Assert.Single(manifest.Commands, command => command.Id == "profile:timezone");
+        var timezoneId = Assert.Single(timezone.Options);
+        Assert.Equal("id", timezoneId.Name);
+        Assert.Equal("String", timezoneId.Type);
+        Assert.True(timezoneId.Required);
+        Assert.True(timezoneId.Autocomplete);
+        Assert.Equal("Timezone ID, e.g. Europe/Oslo or Pacific Standard Time", timezoneId.Description);
+
+        Assert.DoesNotContain(
+            manifest.Commands.SelectMany(command => command.Options),
+            option => option.MinValue is -9007199254740991 || option.MaxValue is 9007199254740991);
+    }
+
+    [Fact]
+    public async Task BuildAsync_SerializesDeterministically()
+    {
+        var first = ManifestJson.Serialize(await CommandManifestBuilder.BuildAsync());
+        var second = ManifestJson.Serialize(await CommandManifestBuilder.BuildAsync());
+
+        Assert.Equal(first, second);
+        Assert.EndsWith("\n", first);
+        Assert.DoesNotContain("\r\n", first, StringComparison.Ordinal);
+    }
+}

--- a/tests/dotBento.Bot.Tests/dotBento.Bot.Tests.csproj
+++ b/tests/dotBento.Bot.Tests/dotBento.Bot.Tests.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="..\..\src\dotBento.Bot\dotBento.Bot.csproj" />
     <ProjectReference Include="..\..\src\dotBento.Infrastructure\dotBento.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\dotBento.EntityFramework\dotBento.EntityFramework.csproj" />
+    <ProjectReference Include="..\..\tools\dotBento.CommandDocs\dotBento.CommandDocs.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/dotBento.CommandDocs/CommandManifest.cs
+++ b/tools/dotBento.CommandDocs/CommandManifest.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace dotBento.CommandDocs;
+
+public sealed record CommandManifest(int SchemaVersion, IReadOnlyList<CommandEntry> Commands);
+
+public sealed record CommandEntry(
+    string Id,
+    IReadOnlyList<string> Path,
+    string Invocation,
+    string Description,
+    IReadOnlyList<GroupEntry> GroupPath,
+    bool GuildOnly,
+    IReadOnlyList<string> RequiredUserPermissions,
+    IReadOnlyList<OptionEntry> Options);
+
+public sealed record GroupEntry(string Name, string Description);
+
+public sealed record OptionEntry(
+    string Name,
+    string Description,
+    string Type,
+    bool Required,
+    object? DefaultValue,
+    IReadOnlyList<ChoiceEntry> Choices,
+    bool Autocomplete,
+    double? MinValue,
+    double? MaxValue,
+    int? MinLength,
+    int? MaxLength,
+    IReadOnlyList<string> ChannelTypes);
+
+public sealed record ChoiceEntry(string Name, object Value);
+
+public static class ManifestJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static string Serialize(CommandManifest manifest) =>
+        JsonSerializer.Serialize(manifest, Options).ReplaceLineEndings("\n") + "\n";
+}

--- a/tools/dotBento.CommandDocs/CommandManifestBuilder.cs
+++ b/tools/dotBento.CommandDocs/CommandManifestBuilder.cs
@@ -1,0 +1,108 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using dotBento.Bot.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System.Runtime.CompilerServices;
+
+namespace dotBento.CommandDocs;
+
+public static class CommandManifestBuilder
+{
+    public static async Task<CommandManifest> BuildAsync()
+    {
+        using var client = new DiscordSocketClient();
+        using var interactions = new InteractionService(client);
+        await interactions.AddModulesAsync(typeof(dotBento.Bot.Program).Assembly, MetadataServiceProvider.Instance);
+
+        var commands = interactions.SlashCommands
+            .Select(BuildCommand)
+            .OrderBy(command => command.Invocation, StringComparer.Ordinal)
+            .ToArray();
+
+        return new CommandManifest(1, commands);
+    }
+
+    private static CommandEntry BuildCommand(SlashCommandInfo command)
+    {
+        var modules = GetModules(command.Module);
+        var groups = modules
+            .Where(module => module.IsSlashGroup)
+            .Select(module => new GroupEntry(module.SlashGroupName, module.Description ?? string.Empty))
+            .ToArray();
+        var path = groups.Select(group => group.Name).Append(command.Name).ToArray();
+        var attributes = modules.SelectMany(module => module.Attributes).Concat(command.Attributes).ToArray();
+        var preconditions = modules.SelectMany(module => module.Preconditions).Concat(command.Preconditions).ToArray();
+        var permissions = preconditions
+            .OfType<RequireUserPermissionAttribute>()
+            .SelectMany(permission => new[] { permission.GuildPermission?.ToString(), permission.ChannelPermission?.ToString() })
+            .Where(permission => permission is not null)
+            .Cast<string>()
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(permission => permission, StringComparer.Ordinal)
+            .ToArray();
+
+        return new CommandEntry(
+            string.Join(':', path),
+            path,
+            "/" + string.Join(' ', path),
+            command.Description,
+            groups,
+            attributes.OfType<GuildOnly>().Any(),
+            permissions,
+            command.Parameters.Select(BuildOption).ToArray());
+    }
+
+    private static OptionEntry BuildOption(SlashCommandParameterInfo option) => new(
+        option.Name,
+        option.Description,
+        option.DiscordOptionType?.ToString() ?? option.ParameterType.Name,
+        option.IsRequired,
+        NormalizeValue(option.DefaultValue),
+        option.Choices.Select(choice => new ChoiceEntry(choice.Name, NormalizeValue(choice.Value) ?? string.Empty)).ToArray(),
+        option.IsAutocomplete,
+        NormalizeLimit(option.MinValue),
+        NormalizeLimit(option.MaxValue),
+        option.MinLength,
+        option.MaxLength,
+        option.ChannelTypes.Select(type => type.ToString()).ToArray());
+
+    private static IReadOnlyList<ModuleInfo> GetModules(ModuleInfo module)
+    {
+        var modules = new Stack<ModuleInfo>();
+        for (ModuleInfo? current = module; current is not null; current = current.Parent)
+            modules.Push(current);
+        return modules.ToArray();
+    }
+
+    private static object? NormalizeValue(object? value) => value switch
+    {
+        null => null,
+        Enum enumValue => enumValue.ToString(),
+        string or bool or byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal => value,
+        _ => value.ToString()
+    };
+
+    private static double? NormalizeLimit(double? value) =>
+        value is -9007199254740991 or 9007199254740991 ? null : value;
+
+    // Discord.Net constructs modules while reflecting them. The exporter never executes
+    // a command, so inert uninitialised dependencies are sufficient and keep this tool
+    // independent from databases, API keys, and the bot host.
+    private sealed class MetadataServiceProvider : IServiceProvider, IServiceScopeFactory, IServiceScope
+    {
+        public static readonly MetadataServiceProvider Instance = new();
+        public IServiceProvider ServiceProvider => this;
+        public IServiceScope CreateScope() => this;
+        public void Dispose() { }
+
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IServiceProvider) || serviceType == typeof(IServiceScopeFactory))
+                return this;
+            return serviceType.IsValueType || serviceType.IsInterface || serviceType.IsAbstract
+                ? null
+                : RuntimeHelpers.GetUninitializedObject(serviceType);
+        }
+    }
+}

--- a/tools/dotBento.CommandDocs/Program.cs
+++ b/tools/dotBento.CommandDocs/Program.cs
@@ -1,0 +1,28 @@
+using dotBento.CommandDocs;
+
+if (args.Length != 3 ||
+    (args[0], args[1]) is not (("export", "--output") or ("check", "--input")))
+{
+    Console.Error.WriteLine("Usage: dotnet run --project tools/dotBento.CommandDocs -- <export --output|check --input> <path>");
+    return 2;
+}
+
+var manifest = ManifestJson.Serialize(await CommandManifestBuilder.BuildAsync());
+var path = Path.GetFullPath(args[2]);
+
+if (args[0] == "export")
+{
+    Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+    await File.WriteAllTextAsync(path, manifest);
+    Console.WriteLine($"Wrote {path}");
+    return 0;
+}
+
+if (!File.Exists(path) || await File.ReadAllTextAsync(path) != manifest)
+{
+    Console.Error.WriteLine($"{path} is stale. Run the exporter and commit the result.");
+    return 1;
+}
+
+Console.WriteLine($"{path} is current.");
+return 0;

--- a/tools/dotBento.CommandDocs/dotBento.CommandDocs.csproj
+++ b/tools/dotBento.CommandDocs/dotBento.CommandDocs.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/dotBento.Bot/dotBento.Bot.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

- add a command manifest exporter and commit the generated slash-command manifest
- validate that manifest in CI and cover the exporter with tests
- dispatch stable release tags to the Bento Docs deployment workflow
- correct the Last.fm recent tracks command and hide-option descriptions

## Documentation flow

Stable GitHub releases dispatch their exact tag to `thebentobot/bento-docs`, keeping public documentation aligned with production rather than unreleased command changes.

## Validation

- 174 bot tests passed
- slash-command manifest freshness check passed
- full Release solution build passed