### PR TITLE
feat: link command errors to troubleshooting docs

### DIFF
--- a/src/dotBento.Bot/Extensions/CommandContextExtensions.cs
+++ b/src/dotBento.Bot/Extensions/CommandContextExtensions.cs
@@ -30,12 +30,12 @@ public static class CommandContextExtensions
             if (exception.Message.Contains("error 50013"))
             {
                 await context.Channel.SendMessageAsync("Sorry, something went wrong because the bot is missing permissions. Make sure the bot has `Embed links` and `Attach Files`.\n" +
-                                                       $"*Reference id: `{referenceId}`*", allowedMentions: AllowedMentions.None);
+                                                       $"*Reference id: `{referenceId}`*\n\n{DiscordConstants.TroubleshootingHelp}", allowedMentions: AllowedMentions.None);
             }
             else
             {
                 await context.Channel.SendMessageAsync("Sorry, something went wrong. Please try again later.\n" +
-                                                       $"*Reference id: `{referenceId}`*", allowedMentions: AllowedMentions.None);
+                                                       $"*Reference id: `{referenceId}`*\n\n{DiscordConstants.TroubleshootingHelp}", allowedMentions: AllowedMentions.None);
             }
         }
 

--- a/src/dotBento.Bot/Extensions/InteractionContextExtensions.cs
+++ b/src/dotBento.Bot/Extensions/InteractionContextExtensions.cs
@@ -49,7 +49,7 @@ public static class InteractionContextExtensions
             }
 
             await context.Interaction.FollowupAsync($"Sorry, something went wrong while trying to process `{commandName}`. Please try again later.\n" +
-                                                    $"*Reference id: `{referenceId}`*", ephemeral: true);
+                                                    $"*Reference id: `{referenceId}`*\n\n{DiscordConstants.TroubleshootingHelp}", ephemeral: true);
         }
 
     }

--- a/src/dotBento.Bot/Handlers/InteractionHandler.cs
+++ b/src/dotBento.Bot/Handlers/InteractionHandler.cs
@@ -5,6 +5,7 @@ using dotBento.Bot.Attributes;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Resources;
 using dotBento.Bot.Utilities;
 using dotBento.Domain;
 using dotBento.Domain.Enums;
@@ -117,7 +118,7 @@ public sealed class InteractionHandler : IDisposable
                         command.Name, context.User.Id, context.Guild?.Id, result.ErrorReason);
                     var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                     embed.Embed.WithTitle("Error: Exception")
-                        .WithDescription($"An exception occurred while executing the command `{command.Name}`\nDon't worry, the developers have been notified and will fix it as soon as possible")
+                        .WithDescription($"An exception occurred while executing the command `{command.Name}`\nDon't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                         .WithColor(Color.Red);
                     await context.SendResponse(_fergunInteractiveService, embed);
                     break;
@@ -127,7 +128,7 @@ public sealed class InteractionHandler : IDisposable
                     Statistics.SlashCommandsFailed.WithLabels(command.Name).Inc();
                     var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                     embed.Embed.WithTitle("Error: Unsuccessful")
-                        .WithDescription($"The command `{command.Name}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible")
+                        .WithDescription($"The command `{command.Name}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                         .WithColor(Color.Red);
                     await context.SendResponse(_fergunInteractiveService, embed);
                     break;
@@ -207,7 +208,7 @@ public sealed class InteractionHandler : IDisposable
                 Statistics.SlashCommandsFailed.WithLabels(commandSearch.Command.Name).Inc();
                 var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                 embed.Embed.WithTitle("Error: Exception")
-                    .WithDescription($"An exception occurred while executing the command `{commandSearch.Command.Name}`\nDon't worry, the developers have been notified and will fix it as soon as possible")
+                    .WithDescription($"An exception occurred while executing the command `{commandSearch.Command.Name}`\nDon't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                     .WithColor(Color.Red);
                 await context.SendResponse(_fergunInteractiveService, embed);
                 break;
@@ -217,7 +218,7 @@ public sealed class InteractionHandler : IDisposable
                 Statistics.SlashCommandsFailed.WithLabels(commandSearch.Command.Name).Inc();
                 var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                 embed.Embed.WithTitle("Error: Unsuccessful")
-                    .WithDescription($"The command `{commandSearch.Command.Name}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible")
+                    .WithDescription($"The command `{commandSearch.Command.Name}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                     .WithColor(Color.Red);
                 await context.SendResponse(_fergunInteractiveService, embed);
                 break;

--- a/src/dotBento.Bot/Handlers/MessageHandler.cs
+++ b/src/dotBento.Bot/Handlers/MessageHandler.cs
@@ -7,6 +7,7 @@ using dotBento.Bot.Commands.SharedCommands;
 using dotBento.Bot.Enums;
 using dotBento.Bot.Extensions;
 using dotBento.Bot.Models.Discord;
+using dotBento.Bot.Resources;
 using dotBento.Bot.Services;
 using dotBento.Bot.Utilities;
 using dotBento.Domain;
@@ -207,7 +208,7 @@ public sealed class MessageHandler : IDisposable
                     Statistics.CommandsFailed.WithLabels(commandName).Inc();
                     var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                     embed.Embed.WithTitle("Error: Exception")
-                        .WithDescription($"An exception occurred while executing the command `{commandName}`\nDon't worry, the developers have been notified and will fix it as soon as possible")
+                        .WithDescription($"An exception occurred while executing the command `{commandName}`\nDon't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                         .WithColor(Color.Red);
                     await context.SendResponse(_interactiveService, embed);
                     break;
@@ -217,7 +218,7 @@ public sealed class MessageHandler : IDisposable
                     Statistics.CommandsFailed.WithLabels(commandName).Inc();
                     var embed = new ResponseModel{ ResponseType = ResponseType.Embed };
                     embed.Embed.WithTitle("Error: Unsuccessful")
-                        .WithDescription($"The command `{commandName}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible")
+                        .WithDescription($"The command `{commandName}` was unsuccessful. Don't worry, the developers have been notified and will fix it as soon as possible.\n\n{DiscordConstants.TroubleshootingHelp}")
                         .WithColor(Color.Red);
                     await context.SendResponse(_interactiveService, embed);
                     break;

--- a/src/dotBento.Bot/Resources/DiscordConstants.cs
+++ b/src/dotBento.Bot/Resources/DiscordConstants.cs
@@ -31,6 +31,11 @@ public sealed class DiscordConstants
 
     public const string WebsiteUrl = "https://bentobot.xyz";
 
+    public const string TroubleshootingUrl = "https://docs.bentobot.xyz/troubleshooting/";
+
+    public const string TroubleshootingHelp =
+        "If the issue persists, see the [troubleshooting guide](" + TroubleshootingUrl + ").";
+
     public const int PaginationTimeoutInSeconds = 120;
 
     public const string FiveOrMoreUp = "<:5_or_more_up:912380324841918504>";


### PR DESCRIPTION
## Summary

- add a canonical troubleshooting documentation URL to Discord constants
- link unexpected slash-command and user-command failures to the troubleshooting guide
- include the same help link in reference-ID and legacy text-command error responses
- keep input-validation errors concise and unchanged

## Validation

- 174 bot tests passed
- 323 infrastructure tests passed
- 101 Web API tests passed
- slash-command documentation manifest remains current
- Release solution build passed with existing warnings